### PR TITLE
fix(execute): run install_cli and other internal tools

### DIFF
--- a/hexagon/cli/config.py
+++ b/hexagon/cli/config.py
@@ -2,6 +2,7 @@ import os
 
 from ruamel.yaml import YAML
 
+CONFIG_FILE_ENV_VARIABLE_NAME = 'HEXAGON_CONFIG_FILE'
 
 class Configuration:
 
@@ -10,7 +11,9 @@ class Configuration:
         self.__config = None
 
     def init_config(self, path):
-        self.project_path = os.environ['HEXAGON_CONFIG_FILE'].replace('app.yaml', '').replace('app.yml', '')
+        if CONFIG_FILE_ENV_VARIABLE_NAME in os.environ:
+          self.project_path = os.environ[CONFIG_FILE_ENV_VARIABLE_NAME].replace('app.yaml', '').replace('app.yml', '')
+
         __defaults = {
             'cli': {'name': 'Hexagon'},
             'tools': {
@@ -59,7 +62,7 @@ class Configuration:
                     'long_name': 'Install CLI',
                     'description': 'Install a custom project CLI from a YAML file.',
                     'type': 'hexagon',
-                    'action': 'install_cli'
+                    'action': 'hexagon.tools.internal.install_cli'
                 }
             },
             {}

--- a/hexagon/cli/execute_tool.py
+++ b/hexagon/cli/execute_tool.py
@@ -21,12 +21,15 @@ def execute_action(action_id: str, args):
 
     if action:
         action(action_id, args)
-    elif __has_no_extension(action_id):
+    elif _is_internal_action(action_id) or __has_no_extension(action_id):
         _execute_python_module(action_id, args)
     else:
         print(f'[red]Executor for extension [bold]{ext}[/bold] not known [dim](supported: .js, .sh).')
         sys.exit(1)
 
+
+def _is_internal_action(action_id):
+  return 'hexagon.tools.internal.' in action_id
 
 def __has_no_extension(action_id):
     return action_id.count('.') == 0

--- a/hexagon/tools/internal/install_cli.py
+++ b/hexagon/tools/internal/install_cli.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from InquirerPy import inquirer
 from InquirerPy.validator import PathValidator
 from prompt_toolkit.validation import ValidationError
+from ruamel.yaml import YAML
 
-from hexagon.cli.config import init_config
 from hexagon.tools.internal.save_new_alias import save_new_alias
 
 
@@ -27,6 +27,7 @@ def main(_):
         validate=YamlFileValidator(is_file=True, message="Please select a valid YAML file")
     ).execute()
 
-    cli_config, tools, envs = init_config(src_path)
+    with open(src_path, 'r') as f:
+      command = YAML().load(f)['cli']['command']    
 
-    save_new_alias(cli_config['command'], f'HEXAGON_CONFIG_FILE={src_path} hexagon')
+    save_new_alias(command, f'HEXAGON_CONFIG_FILE={src_path} hexagon')


### PR DESCRIPTION
Tuve que sacar el import de `hexagon.cli.config` de `install_cli` porque daba error de dependencia circular