### PR TITLE
chore(ci): lint with github action

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -12,5 +12,3 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: TrueBrain/actions-flake8@v2
-        with:
-          ignore: E501

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,16 @@
+name: guidelines
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: TrueBrain/actions-flake8@v2
+        with:
+          ignore: E501

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: build & release
+name: test & release
 
 on:
   push:
@@ -10,8 +10,8 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  test:
+    name: test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -29,15 +29,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 pytest
+          python -m pip install pytest
           python -m pip install -e .
-
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
       - name: Test with pytest
         run: |
@@ -47,7 +40,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
 
     runs-on: ubuntu-latest
-    needs: build
+    needs: test
 
     steps:
       - uses: actions/checkout@v2

--- a/hexagon/cli/execute_tool.py
+++ b/hexagon/cli/execute_tool.py
@@ -29,7 +29,8 @@ def execute_action(action_id: str, args):
 
 
 def _is_internal_action(action_id):
-  return 'hexagon.tools.internal.' in action_id
+    return 'hexagon.tools.internal.' in action_id
+
 
 def __has_no_extension(action_id):
     return action_id.count('.') == 0

--- a/hexagon/cli/execute_tool.py
+++ b/hexagon/cli/execute_tool.py
@@ -37,8 +37,8 @@ def __has_no_extension(action_id):
 
 
 def _execute_python_module(action_id, args):
-    tool_action_module = _load_action_module(action_id) or \
-                         _load_action_module(f'hexagon.tools.external.{action_id}')
+    tool_action_module = _load_action_module(action_id) or _load_action_module(f'hexagon.tools.external.{action_id}')
+
     if not tool_action_module:
         print(f'[red]Hexagon did not find the action [bold]{action_id}')
         print('[red][dim]We checked:')


### PR DESCRIPTION
Se separa el linteo con flake8 a su propio workflow. Por ahora los errores (E501 - lineas largas) se ignoran para que no rompan el pipe ya que en tests e2e vamos a tener muchas lineas largas