### PR TITLE
feat(styles): basic support for hexagon styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ tools:
 
 Run `hexagon` and select the CLI installation tool
 
+## Options
+
+### Theming
+
+Hexagon supports 3 themes for now:
+
+ - default (some nice colors and decorations)
+ - disabled (no colors and no decorations)
+ - result_only (with colors but only shows the result logs)
+
+This can be specified by the envvar `HEXAGON_THEME`, i.e.,
+
+```bash
+# assuming you installed a CLI with command tc
+HEXAGON_THEME=result_only tc
+```
+
+
 ## Development
 
 ### Pre-requisites

--- a/hexagon/__main__.py
+++ b/hexagon/__main__.py
@@ -1,13 +1,12 @@
 import sys
 
-from rich import print
-
 from hexagon.cli.args import fill_args
 from hexagon.cli.config import cli, tools, envs
 from hexagon.cli.execute_tool import execute_action
 from hexagon.cli.help import print_help
 from hexagon.cli.tracer import tracer
 from hexagon.cli.wax import search_by_key_or_alias, select_env, select_tool
+from hexagon.cli.printer import log
 
 
 def main():
@@ -16,13 +15,15 @@ def main():
     if _tool == "-h" or _tool == "--help":
         return print_help(cli, tools, envs)
 
-    print(f'╭╼ [bold]{cli["name"]}')
-    print("│")
+    log.start(f'[bold]{cli["name"]}')
+    log.gap()
 
     if cli["name"] == "Hexagon":
-        print("│ This looks like your first time running Hexagon.")
-        print('│ You should probably run "Install CLI".')
-        print("│")
+        log.info(
+            "This looks like your first time running Hexagon.",
+            'You should probably run "Install CLI".',
+            gap_end=1,
+        )
 
     try:
         _tool = search_by_key_or_alias(tools, _tool)
@@ -36,21 +37,25 @@ def main():
 
         action = execute_action(tool["action"], params)
 
-        print("│")
+        log.gap()
 
         if action:
             for result in action:
-                print(result)
+                log.info(result)
 
-        print("╰╼")
+        log.finish()
 
         if tracer.has_traced() and "command" in cli:
-            print("[cyan dim]Para repetir este comando:[/cyan dim]")
-            print(f'[cyan]     {cli["command"]} {tracer.command()}[/cyan]')
+            log.extra(
+                "[cyan dim]Para repetir este comando:[/cyan dim]",
+                f'[cyan]     {cli["command"]} {tracer.command()}[/cyan]',
+            )
             command_as_aliases = tracer.command_as_aliases(tools, envs)
             if command_as_aliases:
-                print("[cyan dim]  o:[/cyan dim]")
-                print(f'[cyan]     {cli["command"]} {command_as_aliases}[/cyan]')
+                log.extra(
+                    "[cyan dim]  o:[/cyan dim]",
+                    f'[cyan]     {cli["command"]} {command_as_aliases}[/cyan]',
+                )
             dump = open("last_command", "w")
             dump.write(f'{cli["command"]} {tracer.command()}')
             dump.close()

--- a/hexagon/cli/__templates/custom_tool/__init__.py
+++ b/hexagon/cli/__templates/custom_tool/__init__.py
@@ -2,10 +2,10 @@ import sys
 
 from InquirerPy import inquirer
 from InquirerPy.validator import EmptyInputValidator
-from rich import print
 
 from hexagon.cli.args import fill_args
 from hexagon.cli.tracer import tracer
+from hexagon.cli.printer import log
 
 
 # Toda tool de hexagon tiene que tener un main que se va a invocar
@@ -32,5 +32,5 @@ def main(env_values):
         ).execute()
     )
 
-    print("Valor en tool.envs:", env_values)
-    print("tu apellido es:", name)
+    log.info("Valor en tool.envs:", env_values)
+    log.info("tu apellido es:", name)

--- a/hexagon/cli/execute_tool.py
+++ b/hexagon/cli/execute_tool.py
@@ -2,9 +2,8 @@ import importlib
 import subprocess
 import sys
 
-from rich import print
-
 from hexagon.cli.config import configuration
+from hexagon.cli.printer import log
 
 
 def execute_action(action_id: str, args):
@@ -16,8 +15,8 @@ def execute_action(action_id: str, args):
     elif _is_internal_action(action_id) or __has_no_extension(action_id):
         _execute_python_module(action_id, args)
     else:
-        print(
-            f"[red]Executor for extension [bold]{ext}[/bold] not known [dim](supported: .js, .sh)."
+        log.error(
+            f"Executor for extension [bold]{ext}[/bold] not known [dim](supported: .js, .sh)."
         )
         sys.exit(1)
 
@@ -36,20 +35,20 @@ def _execute_python_module(action_id, args):
     )
 
     if not tool_action_module:
-        print(f"[red]Hexagon did not find the action [bold]{action_id}")
-        print("[red][dim]We checked:")
-        print(
-            f"[red][dim]     - Your CLI's custom_tools_dir: [bold]{configuration.custom_tools_path}"
+        log.error(f"Hexagon did not find the action [bold]{action_id}")
+        log.error("[dim]We checked:")
+        log.error(
+            f"[dim]     - Your CLI's custom_tools_dir: [bold]{configuration.custom_tools_path}"
         )
-        print(
-            "[red][dim]     - Hexagon repository of externals tools (hexagon.tools.external)"
+        log.error(
+            "[dim]     - Hexagon repository of externals tools (hexagon.tools.external)"
         )
         sys.exit(1)
     try:
         tool_action_module.main(args)
     except AttributeError as e:
-        print(f"[red]Execution of tool [bold]{action_id}[/bold] thru: {e}")
-        print("[red]Does it have the required `main(args...)` method?")
+        log.error(f"Execution of tool [bold]{action_id}[/bold] thru: {e}")
+        log.error("Does it have the required `main(args...)` method?")
         sys.exit(1)
 
 

--- a/hexagon/cli/help.py
+++ b/hexagon/cli/help.py
@@ -1,6 +1,6 @@
 from itertools import groupby
 
-from rich import print
+from hexagon.cli.printer import log
 
 
 def print_help(cli_config: dict, tools: dict, envs: dict):
@@ -13,22 +13,18 @@ def print_help(cli_config: dict, tools: dict, envs: dict):
     :return:
     """
     if cli_config["name"] == "Hexagon":
-        print("│ [bold]Hexagon")
-        print("│")
-        print("│ You are executing Hexagon without an install.")
-        print('│ To get started run hexagon\'s "Install Hexagon" tool')
+        log.info("[bold]Hexagon", gap_end=1)
+        log.info("You are executing Hexagon without an install.")
+        log.info('To get started run hexagon\'s "Install Hexagon" tool')
         return
 
-    print(f'│ [bold]{cli_config["name"]}')
+    log.info(f'[bold]{cli_config["name"]}', gap_end=1)
 
-    print("│")
-    print("│ [bold][u]Envs:")
+    log.info("[bold][u]Envs:")
     for k, v in envs.items():
-        print(f'│   {k + (" (" + v["alias"] + ")" if "alias" in v else "")}')
+        log.info(f'  {k + (" (" + v["alias"] + ")" if "alias" in v else "")}')
 
-    print("│")
-    print("│")
-    print("│ [bold][u]Tools:")
+    log.info("[bold][u]Tools:", gap_start=2)
 
     def key_func(z):
         x, y = z
@@ -37,13 +33,11 @@ def print_help(cli_config: dict, tools: dict, envs: dict):
     data = sorted(tools.items(), key=key_func, reverse=True)
 
     for gk, g in groupby(data, key_func):
-        print("│")
-        print(f"│ [bold]{gk}:")
+        log.info(f"[bold]{gk}:", gap_start=1)
 
         for k, v in g:
-            print(
-                f'│   {k + (" (" + v["alias"] + ")" if "alias" in v else ""):<60}[dim]{v.get("long_name", "")}'
+            log.info(
+                f'  {k + (" (" + v["alias"] + ")" if "alias" in v else ""):<60}[dim]{v.get("long_name", "")}'
             )
             if "description" in v:
-                print(f'│   {"": <60}[dim]{v["description"]}')
-                print("│")
+                log.info(f'  {"": <60}[dim]{v["description"]}', gap_end=1)

--- a/hexagon/cli/printer.py
+++ b/hexagon/cli/printer.py
@@ -28,7 +28,7 @@ class Logger:
 
     def gap(self, repeat: int = 1):
         if not self.__decorations.result_only:
-            for n in range(repeat):
+            for _ in range(repeat):
                 self.__console.print(self.__decorations.border)
 
     def info(self, *message: str, gap_start: int = 0, gap_end: int = 0):

--- a/hexagon/cli/printer.py
+++ b/hexagon/cli/printer.py
@@ -1,0 +1,87 @@
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from rich.console import Console
+
+
+@dataclass
+class LoggingStyle:
+    show_colors: bool = True
+    result_only: bool = False
+    start: str = ""
+    border: str = ""
+    border_result: str = ""
+    process_out: str = ""
+    process_in: str = ""
+    finish: str = ""
+
+
+class Logger:
+    def __init__(self, console: Console, decorations: LoggingStyle) -> None:
+        self.__console = console
+        self.__decorations = decorations
+
+    def start(self, message: str):
+        if not self.__decorations.result_only:
+            self.__console.print(f"{self.__decorations.start}{message}")
+
+    def gap(self, repeat: int = 1):
+        if not self.__decorations.result_only:
+            for n in range(repeat):
+                self.__console.print(self.__decorations.border)
+
+    def info(self, *message: str, gap_start: int = 0, gap_end: int = 0):
+        if not self.__decorations.result_only:
+            self.gap(gap_start)
+            for msg in message:
+                self.__console.print(f"{self.__decorations.border}{msg}")
+            self.gap(gap_end)
+
+    def result(self, message: str):
+        self.__console.print(f"{self.__decorations.border_result}{message}")
+
+    def example(self, *message: str):
+        if not self.__decorations.result_only:
+            self.__console.print(f"{self.__decorations.process_out}\n")
+
+        for msg in message:
+            self.__console.print(msg)
+
+        if not self.__decorations.result_only:
+            self.__console.print(f"\n{self.__decorations.process_in}")
+
+    def error(self, message: str, err: Optional[Exception] = None):
+        self.__console.print(f"[red]{message}")
+        if err:
+            self.__console.print(err)
+
+    def extra(self, *message: str):
+        if not self.__decorations.result_only:
+            for msg in message:
+                self.__console.print(msg)
+
+    def finish(self, message: str = None):
+        if not self.__decorations.result_only:
+            self.__console.print(f"{self.__decorations.finish}{message or ''}")
+
+
+__styles = {
+    "default": LoggingStyle(
+        start="╭╼ ",
+        border="│ ",
+        border_result="├ ",
+        process_out="┆",
+        process_in="┆",
+        finish="╰╼ ",
+    ),
+    "disabled": LoggingStyle(show_colors=False),
+    "result_only": LoggingStyle(result_only=True),
+}
+
+style = __styles[os.getenv("HEXAGON_STYLE", "default")]
+
+log = Logger(
+    Console(color_system="auto" if style.show_colors else None),
+    style,
+)

--- a/hexagon/cli/printer/__init__.py
+++ b/hexagon/cli/printer/__init__.py
@@ -1,0 +1,11 @@
+from rich.console import Console
+
+from hexagon.cli.printer.logger import Logger
+from hexagon.cli.printer.themes import load_theme
+
+theme = load_theme()
+
+log = Logger(
+    Console(color_system="auto" if theme.show_colors else None),
+    theme,
+)

--- a/hexagon/cli/printer/logger.py
+++ b/hexagon/cli/printer/logger.py
@@ -1,24 +1,12 @@
-import os
-from dataclasses import dataclass
 from typing import Optional
 
 from rich.console import Console
 
-
-@dataclass
-class LoggingStyle:
-    show_colors: bool = True
-    result_only: bool = False
-    start: str = ""
-    border: str = ""
-    border_result: str = ""
-    process_out: str = ""
-    process_in: str = ""
-    finish: str = ""
+from hexagon.cli.printer.themes import LoggingTheme
 
 
 class Logger:
-    def __init__(self, console: Console, decorations: LoggingStyle) -> None:
+    def __init__(self, console: Console, decorations: LoggingTheme) -> None:
         self.__console = console
         self.__decorations = decorations
 
@@ -64,24 +52,3 @@ class Logger:
     def finish(self, message: str = None):
         if not self.__decorations.result_only:
             self.__console.print(f"{self.__decorations.finish}{message or ''}")
-
-
-__styles = {
-    "default": LoggingStyle(
-        start="╭╼ ",
-        border="│ ",
-        border_result="├ ",
-        process_out="┆",
-        process_in="┆",
-        finish="╰╼ ",
-    ),
-    "disabled": LoggingStyle(show_colors=False),
-    "result_only": LoggingStyle(result_only=True),
-}
-
-style = __styles[os.getenv("HEXAGON_STYLE", "default")]
-
-log = Logger(
-    Console(color_system="auto" if style.show_colors else None),
-    style,
-)

--- a/hexagon/cli/printer/themes.py
+++ b/hexagon/cli/printer/themes.py
@@ -1,0 +1,66 @@
+import os
+from dataclasses import dataclass, fields
+
+
+@dataclass
+class PromptsTheme:
+    questionmark: str = "#e5c07b"
+    answer: str = "#61afef"
+    input: str = "#98c379"
+    question: str = ""
+    instruction: str = ""
+    pointer: str = "#61afef"
+    checkbox: str = "#98c379"
+    separator: str = ""
+    skipped: str = "#5c6370"
+    validator: str = ""
+    marker: str = ""
+    fuzzy_prompt: str = "#c678dd"
+    fuzzy_info: str = "#56b6c2"
+    fuzzy_border: str = "#4b5263"
+    fuzzy_match: str = "#c678dd"
+
+
+@dataclass
+class LoggingTheme:
+    show_colors: bool = True
+    result_only: bool = False
+    start: str = ""
+    border: str = ""
+    border_result: str = ""
+    process_out: str = ""
+    process_in: str = ""
+    finish: str = ""
+    prompts: PromptsTheme = PromptsTheme()
+
+    def __getitem__(self, item: str):
+        if item.startswith("prompts."):
+            return (
+                getattr(self.prompts, item.replace("prompts.", ""))
+                if self.show_colors
+                else ""
+            )
+        return getattr(self, item)
+
+
+def load_theme():
+    __themes = {
+        "default": LoggingTheme(
+            start="╭╼ ",
+            border="│ ",
+            border_result="├ ",
+            process_out="┆",
+            process_in="┆",
+            finish="╰╼ ",
+        ),
+        "disabled": LoggingTheme(show_colors=False),
+        "result_only": LoggingTheme(result_only=True),
+    }
+
+    t = __themes[os.getenv("HEXAGON_THEME", "default")]
+
+    for f in fields(t.prompts):
+        n = f"INQUIRERPY_STYLE_{f.name.upper()}"
+        os.environ[n] = os.getenv(n, t[f"prompts.{f.name}"])
+
+    return t

--- a/hexagon/tools/external/docker_registry.py
+++ b/hexagon/tools/external/docker_registry.py
@@ -5,10 +5,10 @@ import sys
 import clipboard
 import requests
 from InquirerPy import inquirer
-from rich import print
 
 from hexagon.cli.args import fill_args
 from hexagon.cli.tracer import tracer
+from hexagon.cli.printer import log
 
 
 def main(registry_host):
@@ -42,7 +42,7 @@ def main(registry_host):
     )
 
     clipboard.copy(f"{registry_host}/{image}:{tag}")
-    print(f"├ [dim][u]{registry_host}/{image}:{tag}[/u] se copió al portapapeles")
+    log.result(f"[dim][u]{registry_host}/{image}:{tag}[/u] se copió al portapapeles")
 
     manifest = inquirer.confirm(
         message="¿Te gustaría ver el manifest?", default=False

--- a/hexagon/tools/external/open_link.py
+++ b/hexagon/tools/external/open_link.py
@@ -1,6 +1,8 @@
 import webbrowser
 
+from hexagon.cli.printer import log
+
 
 def main(url):
-    print("├ Abriendo link: " + url)
+    log.result("Abriendo link: " + url)
     webbrowser.open(url)

--- a/hexagon/tools/internal/create_new_tool.py
+++ b/hexagon/tools/internal/create_new_tool.py
@@ -3,10 +3,10 @@ from shutil import copytree
 
 from InquirerPy import inquirer
 from InquirerPy.validator import PathValidator
-from rich import print
 
 from hexagon.cli.config import configuration
 from hexagon.tools import external
+from hexagon.cli.printer import log
 
 
 def main(_):
@@ -55,7 +55,7 @@ def main(_):
 
     if create_action:
         if not configuration.custom_tools_path:
-            print("│ [magenta]Your CLI does not have a custom tools dir.")
+            log.info("[magenta]Your CLI does not have a custom tools dir.")
             configuration.update_custom_tools_path(
                 inquirer.filepath(
                     message="Where would you like it to be? "

--- a/hexagon/tools/internal/save_new_alias.py
+++ b/hexagon/tools/internal/save_new_alias.py
@@ -2,7 +2,8 @@ import os
 
 from InquirerPy import inquirer
 from InquirerPy.validator import EmptyInputValidator
-from rich import print
+
+from hexagon.cli.printer import log
 
 
 def main(_):
@@ -44,8 +45,6 @@ def save_new_alias(alias_name, command):
 
 
 def __pretty_print_created_alias(aliases_file, file, lines_to_show=-10):
-    print("│")
-    print(f"│ Added alias to {file}")
-    print("┆\n")
-    print("\n".join(aliases_file.read().splitlines()[lines_to_show:]))
-    print("\n┆")
+    log.gap()
+    log.info(f"Added alias to {file}")
+    log.example("\n".join(aliases_file.read().splitlines()[lines_to_show:]))

--- a/tests/cli/test_printer.py
+++ b/tests/cli/test_printer.py
@@ -1,6 +1,7 @@
 import pytest
 
-from hexagon.cli.printer import Logger, LoggingStyle
+from hexagon.cli.printer import Logger
+from hexagon.cli.printer.themes import LoggingTheme
 
 
 class Console:
@@ -27,7 +28,7 @@ class Console:
 def test_log_start(decoration, message, expected):
     console = Console()
 
-    Logger(console, LoggingStyle(start=decoration)).start(message)
+    Logger(console, LoggingTheme(start=decoration)).start(message)
 
     assert console.output == expected
 
@@ -49,7 +50,7 @@ def test_log_start(decoration, message, expected):
 def test_log_gap(border, repeat, expected):
     console = Console()
 
-    Logger(console, LoggingStyle(border=border)).gap(repeat)
+    Logger(console, LoggingTheme(border=border)).gap(repeat)
 
     assert console.output == expected
 
@@ -67,7 +68,7 @@ def test_log_gap(border, repeat, expected):
 def test_log_info(decoration, message, gap_start, gap_end, expected):
     console = Console()
 
-    Logger(console, LoggingStyle(border=decoration)).info(
+    Logger(console, LoggingTheme(border=decoration)).info(
         message, gap_start=gap_start, gap_end=gap_end
     )
 
@@ -94,7 +95,7 @@ def test_log_info_with_multiple_message(
 ):
     console = Console()
 
-    Logger(console, LoggingStyle(border=decoration)).info(
+    Logger(console, LoggingTheme(border=decoration)).info(
         *message, gap_start=gap_start, gap_end=gap_end
     )
 
@@ -112,7 +113,7 @@ def test_log_info_with_multiple_message(
 def test_log_result(decoration, message, expected):
     console = Console()
 
-    Logger(console, LoggingStyle(border_result=decoration)).result(message)
+    Logger(console, LoggingTheme(border_result=decoration)).result(message)
 
     assert console.output == expected
 
@@ -134,7 +135,7 @@ def test_log_example(process_out, process_in, message, expected):
     console = Console()
 
     Logger(
-        console, LoggingStyle(process_out=process_out, process_in=process_in)
+        console, LoggingTheme(process_out=process_out, process_in=process_in)
     ).example(message)
 
     assert console.output == expected

--- a/tests/cli/test_printer.py
+++ b/tests/cli/test_printer.py
@@ -1,0 +1,140 @@
+import pytest
+
+from hexagon.cli.printer import Logger, LoggingStyle
+
+
+class Console:
+    def __init__(self) -> None:
+        super().__init__()
+        self.__output = []
+
+    def print(self, value):
+        self.__output.append(value)
+
+    @property
+    def output(self):
+        return "\n".join(self.__output)
+
+
+@pytest.mark.parametrize(
+    "decoration,message,expected",
+    [
+        ("", "", ""),
+        ("╭╼ ", "docker", "╭╼ docker"),
+        ("╭╼            ", "sarasa asdfasd ", "╭╼            sarasa asdfasd "),
+    ],
+)
+def test_log_start(decoration, message, expected):
+    console = Console()
+
+    Logger(console, LoggingStyle(start=decoration)).start(message)
+
+    assert console.output == expected
+
+
+@pytest.mark.parametrize(
+    "border,repeat,expected",
+    [
+        ("", 1, ""),
+        ("│", 1, "│"),
+        ("│", 0, ""),
+        (
+            "border",
+            5,
+            "\n".join(["border", "border", "border", "border", "border"]),
+        ),
+        ("│         ", 1, "│         "),
+    ],
+)
+def test_log_gap(border, repeat, expected):
+    console = Console()
+
+    Logger(console, LoggingStyle(border=border)).gap(repeat)
+
+    assert console.output == expected
+
+
+@pytest.mark.parametrize(
+    "decoration,message,gap_start,gap_end,expected",
+    [
+        ("", "hello", 0, 0, "hello"),
+        ("│", "hello", 0, 0, "│hello"),
+        ("│ ", "hello", 0, 0, "│ hello"),
+        ("│ ", "hello", 1, 1, "│ \n│ hello\n│ "),
+        ("│ ", "hello", 5, 1, "│ \n│ \n│ \n│ \n│ \n│ hello\n│ "),
+    ],
+)
+def test_log_info(decoration, message, gap_start, gap_end, expected):
+    console = Console()
+
+    Logger(console, LoggingStyle(border=decoration)).info(
+        message, gap_start=gap_start, gap_end=gap_end
+    )
+
+    assert console.output == expected
+
+
+@pytest.mark.parametrize(
+    "decoration,message,gap_start,gap_end,expected",
+    [
+        ("│ ", ("hello", "world"), 0, 0, "│ hello\n│ world"),
+        ("│ ", ("hello", "world"), 2, 3, "│ \n│ \n│ hello\n│ world\n│ \n│ \n│ "),
+        ("│ ", ("hello", ""), 0, 0, "│ hello\n│ "),
+        (
+            "│ ",
+            ("hello", "world", "how", "are", "you"),
+            0,
+            0,
+            "│ hello\n│ world\n│ how\n│ are\n│ you",
+        ),
+    ],
+)
+def test_log_info_with_multiple_message(
+    decoration, message, gap_start, gap_end, expected
+):
+    console = Console()
+
+    Logger(console, LoggingStyle(border=decoration)).info(
+        *message, gap_start=gap_start, gap_end=gap_end
+    )
+
+    assert console.output == expected
+
+
+@pytest.mark.parametrize(
+    "decoration,message,expected",
+    [
+        ("", "", ""),
+        ("├ ", "docker", "├ docker"),
+        ("├            ", "sarasa asdfasd ", "├            sarasa asdfasd "),
+    ],
+)
+def test_log_result(decoration, message, expected):
+    console = Console()
+
+    Logger(console, LoggingStyle(border_result=decoration)).result(message)
+
+    assert console.output == expected
+
+
+@pytest.mark.parametrize(
+    "process_out,process_in,message,expected",
+    [
+        ("", "", "", "\n\n\n\n"),
+        ("┆", "┆", "docker", "┆\n\ndocker\n\n┆"),
+        (
+            "┆",
+            "",
+            "sarasa asdfasd ",
+            "┆\n\nsarasa asdfasd \n\n",
+        ),
+    ],
+)
+def test_log_example(process_out, process_in, message, expected):
+    console = Console()
+
+    Logger(
+        console, LoggingStyle(process_out=process_out, process_in=process_in)
+    ).example(message)
+
+    assert console.output == expected


### PR DESCRIPTION
- [x] esperar a mergear #13 así tenemos mejor cobertura de e2e

Se esconde `rich` detrás de propia clase para "estandarizar" el logging de hexagon.

Configuración de estilo con envvar `HEXAGON_THEME`:

"default"
![image](https://user-images.githubusercontent.com/11464844/123889895-bd246700-d92c-11eb-9693-84512dae73a9.png)


"disabled" (apaga colores de rich)
![image](https://user-images.githubusercontent.com/11464844/123889831-a251f280-d92c-11eb-9a74-883d9fb642ee.png)

"result_only"
![image](https://user-images.githubusercontent.com/11464844/123889999-e3e29d80-d92c-11eb-9d3c-882d7c396d4e.png)


Aprendizajes:

- [rich color_systems](https://rich.readthedocs.io/en/stable/console.html#color-systems) por defecto detecta si estás ejecutando en un terminal o no, y te habilita o no los colores.
- si queremos podríamos jugar con [InquirerPy custom styles](https://github.com/kazhala/InquirerPy/wiki/Style#customizing-style) para eliminar los colores y el borde de los prompts.
