### PR TITLE
feat: define tools & envs as lists instead of dict

### DIFF
--- a/e2e/execute_tool/app.yml
+++ b/e2e/execute_tool/app.yml
@@ -4,28 +4,28 @@ cli:
   custom_tools_dir: .
 
 envs:
-  dev:
+  - name: dev
     alias: d
     long_name: dev
-  qa:
+  - name: qa
     alias: q
     long_name: qa
 
 tools:
-  google:
+  - name: google
     long_name: Google
     type: web
     action: open_link
     envs:
       "*": https://www.google.com/
 
-  python-module:
+  - name: python-module
     action: python-module
     type: shell
     alias: pm
     long_name: Python Module Test
 
-  python-module-env:
+  - name: python-module-env
     action: python-module
     type: shell
     alias: pme
@@ -38,7 +38,7 @@ tools:
         foo: foo
         bar: bar
 
-  python-module-env-all:
+  - name: python-module-env-all
     action: python-module
     type: shell
     alias: python-module-env-all
@@ -46,13 +46,13 @@ tools:
     envs:
       "*": all_envs
 
-  node-module:
+  - name: node-module
     action: node-module.js
     type: shell
     alias: nm
     long_name: Node Module Test
 
-  node-module-env:
+  - name: node-module-env
     action: node-module.js
     type: shell
     alias: nme
@@ -65,13 +65,13 @@ tools:
         foo: foo
         bar: bar
 
-  generic-command:
+  - name: generic-command
     action: 'echo "executed generic-command"'
     type: shell
     alias: gc
     long_name: A generic command
 
-  failing-command:
+  - name: failing-command
     action: i-dont-exist
     type: shell
     alias: fc

--- a/e2e/install_cli/config.yml
+++ b/e2e/install_cli/config.yml
@@ -2,8 +2,9 @@ cli:
   name: Test
   command: hexagon-test
   custom_tools_dir: .
+
 tools:
-  google:
+  - name: google
     long_name: Google
     type: web
     action: 'open_link'
@@ -11,5 +12,5 @@ tools:
       '*': https://www.google.com/
 
 envs:
-  dev:
+  - name: dev
     alias: d

--- a/e2e/save_alias/app.yml
+++ b/e2e/save_alias/app.yml
@@ -3,9 +3,9 @@ cli:
   command: hexagon-test
   custom_tools_dir: .
 tools:
-  python-module:
+  - name: python-module
     action: python-module
     type: shell
     alias: pm
     long_name: Python Module Test
-envs: {}
+envs: []

--- a/e2e/tests/create_new_tool.py
+++ b/e2e/tests/create_new_tool.py
@@ -10,8 +10,10 @@ DESCRIPTION = "Hexagon Custom Action Test Description"
 
 base_app_file = {
     "cli": {"name": "Test", "command": "hexagon-test", "custom_tools_dir": "."},
-    "tools": {"google": {"long_name": "Google", "type": "web", "action": "open_link"}},
-    "envs": {},
+    "tools": [
+        {"name": "google", "long_name": "Google", "type": "web", "action": "open_link"}
+    ],
+    "envs": [],
 }
 
 
@@ -95,7 +97,7 @@ def test_create_new_open_link_tool():
     )
 
     app_file = read_hexagon_config(__file__)
-    created_tool = app_file["tools"]["open-link-test"]
+    created_tool = app_file["tools"][1]
     assert created_tool["action"] == "open_link"
     assert created_tool["type"] == "web"
     assert created_tool["alias"] == "olt"
@@ -141,7 +143,7 @@ def test_create_new_python_module_tool():
     )
 
     app_file = read_hexagon_config(__file__)
-    created_tool = app_file["tools"]["a-new-action-command"]
+    created_tool = app_file["tools"][1]
     assert created_tool["action"] == "a-new-action"
     assert created_tool["type"] == "shell"
     assert created_tool["alias"] == "anac"

--- a/e2e/tests/ux_create_tool_and_execute.py
+++ b/e2e/tests/ux_create_tool_and_execute.py
@@ -9,8 +9,10 @@ DESCRIPTION = "Hexagon Custom Action Test Description"
 
 config_file = {
     "cli": {"name": "Test", "command": "hexagon-test", "custom_tools_dir": "."},
-    "tools": {"google": {"long_name": "Google", "type": "web", "action": "open_link"}},
-    "envs": {},
+    "tools": [
+        {"name": "google", "long_name": "Google", "type": "web", "action": "open_link"}
+    ],
+    "envs": [],
 }
 
 

--- a/e2e/tests/validate_yaml.py
+++ b/e2e/tests/validate_yaml.py
@@ -13,7 +13,7 @@ def test_show_errors_when_invalid_yaml():
                 "field required (type=value_error.missing)",
                 "envs",
                 "field required (type=value_error.missing)",
-                "tools -> google-invalid -> action",
+                "tools -> 0 -> action",
                 "field required (type=value_error.missing)",
             ]
         )

--- a/e2e/validate_yaml/app.yml
+++ b/e2e/validate_yaml/app.yml
@@ -3,11 +3,11 @@ cli:
   custom_tools_dir: .
 
 tools:
-  google-invalid:
+  - name: google-invalid
     long_name: Google
     type: web
 
-  google-valid:
+  - name: google-valid
     long_name: Google
     type: web
     action: 'open_link'

--- a/hexagon/__main__.py
+++ b/hexagon/__main__.py
@@ -5,7 +5,7 @@ from hexagon.domain import cli, tools, envs
 from hexagon.support.execute_tool import execute_action
 from hexagon.support.help import print_help
 from hexagon.support.tracer import tracer
-from hexagon.support.wax import search_by_key_or_alias, select_env, select_tool
+from hexagon.support.wax import search_by_name_or_alias, select_env, select_tool
 from hexagon.support.printer import log
 from hexagon.support.storage import (
     HexagonStorageKeys,
@@ -30,8 +30,8 @@ def main():
         )
 
     try:
-        _tool = search_by_key_or_alias(tools, _tool)
-        _env = search_by_key_or_alias(envs, _env)
+        _tool = search_by_name_or_alias(tools, _tool)
+        _env = search_by_name_or_alias(envs, _env)
 
         name, tool = select_tool(tools, _tool)
         tracer.tracing(name)
@@ -39,7 +39,10 @@ def main():
         env, params = select_env(envs, tool.envs, _env)
         tracer.tracing(env)
 
-        action = execute_action(tool, params, envs.get(env, None), sys.argv[3:])
+        # TODO: next() probably should be inside select_env
+        action = execute_action(
+            tool, params, next((e for e in envs if e.name == env), None), sys.argv[3:]
+        )
 
         log.gap()
 

--- a/hexagon/domain/env.py
+++ b/hexagon/domain/env.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 
 class Env(BaseModel):
+    name: str
     alias: Optional[str] = None
     long_name: Optional[str] = None
     description: Optional[str] = None

--- a/hexagon/domain/tool.py
+++ b/hexagon/domain/tool.py
@@ -12,6 +12,7 @@ class ToolType(str, Enum):
 
 
 class Tool(BaseModel):
+    name: str
     action: str
     type: ToolType = ToolType.misc
     alias: Optional[str] = None

--- a/hexagon/support/execute_tool.py
+++ b/hexagon/support/execute_tool.py
@@ -69,7 +69,7 @@ def _execute_python_module(action_id: str, tool: Tool, env: Env, env_args, args)
         tool_action_module.main(tool, env, env_args, args)
         return True
     except AttributeError as e:
-        log.error(f"Execution of tool [bold]{action_id}[/bold] thru: {e}")
+        log.error(f"Execution of tool [bold]{action_id}[/bold] thru: {e}", e)
         log.error("Does it have the required `main(args...)` method?")
         sys.exit(1)
 

--- a/hexagon/support/tracer.py
+++ b/hexagon/support/tracer.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Dict
+from typing import List
 
 from hexagon.domain.env import Env
 from hexagon.domain.tool import Tool
@@ -18,18 +18,18 @@ class Tracer:
     def command(self):
         return " ".join(self.trace)
 
-    def command_as_aliases(
-        self, tools_dict: Dict[str, Tool], envs_dict: Dict[str, Env]
-    ):
+    def command_as_aliases(self, tools: List[Tool], envs: List[Env]):
         if len(self.trace) < 1:
             return ""
 
-        _tool_alias = tools_dict[self.trace[:1][0]].alias
+        _tool_alias = next(
+            (t.alias for t in tools if t.name == self.trace[:1][0]), None
+        )
         if not _tool_alias:
             return None
 
         try:
-            al = envs_dict.get(self.trace[1:2][0], Env()).alias
+            al = next((x.alias for x in envs if x.name == self.trace[1:2][0]), "")
             _env_alias = [al] if al else []
         except IndexError:
             _env_alias = []

--- a/hexagon/support/wax.py
+++ b/hexagon/support/wax.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Union, List
 
 from InquirerPy import inquirer
 
@@ -6,35 +6,33 @@ from hexagon.domain.env import Env
 from hexagon.domain.tool import Tool
 
 
-def __classifier(value: Tool):
+def __classifier(value: Union[Tool, Env]):
     symbols = {"web": "⦾", "shell": "ƒ", "misc": " ", "hexagon": "⬡"}
     r = symbols.get(value.type, "")
     return f"{r:2}" if r else ""
 
 
-def __choices_with_long_name(dic: Dict[str, Union[Tool, Env]], classifier=lambda x: ""):
-    def build_display(v: Union[Tool, Env], k: str):
-        if "__separator" in k:
+def __choices_with_long_name(choices: List[Union[Tool, Env]], classifier=lambda x: ""):
+    def build_display(v: Union[Tool, Env]):
+        if "__separator" in v.name:
             return "--------------------------------------------------------------------------------"
         else:
             gap = 60 if v.description else 0
-            return f"{classifier(v) + (v.long_name or k): <{gap}}{v.description or ''}"
+            return f"{classifier(v) + (v.long_name or v.name): <{gap}}{v.description or ''}"
 
-    return [{"value": k, "name": build_display(v, k)} for k, v in dic.items()]
+    return [{"value": each.name, "name": build_display(each)} for each in choices]
 
 
-def search_by_key_or_alias(dic: Dict[str, Union[Tool, Env]], arg: str):
+def search_by_name_or_alias(data: List[Union[Tool, Env]], arg: str):
     if arg:
-        for k, v in dic.items():
-            if k == arg or v.alias == arg:
-                return k
+        for k in data:
+            if k.name == arg or k.alias == arg:
+                return k.name
 
     return None
 
 
-def select_env(
-    available_envs: Dict[str, Env], tool_envs: dict = None, selected: str = None
-):
+def select_env(available_envs: List[Env], tool_envs: dict = None, selected: str = None):
     if not tool_envs:
         return None, None
 
@@ -44,11 +42,11 @@ def select_env(
     if selected:
         return selected, tool_envs[selected]
 
-    qs = {k: available_envs[k] for k in tool_envs.keys()}
-
     env = inquirer.fuzzy(
         message="On which environment?",
-        choices=__choices_with_long_name(qs),
+        choices=__choices_with_long_name(
+            [e for e in available_envs if e.name in tool_envs.keys()]
+        ),
         validate=lambda x: x and "__separator" not in x,
         invalid_message="Please select a valid environment",
     ).execute()
@@ -56,15 +54,15 @@ def select_env(
     return env, tool_envs[env]
 
 
-def select_tool(tools_dict: Dict[str, Tool], selected: str = None):
+def select_tool(tools: List[Tool], selected: str = None):
     if selected:
-        return selected, tools_dict[selected]
+        return selected, next(t for t in tools if t.name == selected)
 
     name = inquirer.fuzzy(
         message="Hi, which tool would you like to use today?",
-        choices=__choices_with_long_name(tools_dict, classifier=__classifier),
+        choices=__choices_with_long_name(tools, classifier=__classifier),
         validate=lambda x: x and "__separator" not in x,
         invalid_message="Please select a valid tool",
     ).execute()
 
-    return name, tools_dict[name]
+    return name, next(t for t in tools if t.name == name)

--- a/hexagon/tools/internal/create_new_tool.py
+++ b/hexagon/tools/internal/create_new_tool.py
@@ -13,11 +13,12 @@ from hexagon.support.printer import log
 def main(*_):
     create_action = False
     new_tool = Tool(
+        name="invalid",
         action=inquirer.fuzzy(
             message="Choose the action of your tool:",
             validate=lambda x: x,
             choices=external.__all__ + ["new_action"],
-        ).execute()
+        ).execute(),
     )
 
     if new_tool.action == "new_action":
@@ -36,7 +37,7 @@ def main(*_):
         default=ToolType.web if new_tool.action == "open_link" else ToolType.shell,
     ).execute()
 
-    command = inquirer.text(
+    new_tool.name = inquirer.text(
         message="What command would you like to give your tool?",
         validate=lambda x: x,
         default=new_tool.action.replace("_", "-"),
@@ -44,7 +45,7 @@ def main(*_):
 
     new_tool.alias = inquirer.text(
         message="Would you like to add an alias/shortcut? (empty for none)",
-        default="".join([z[:1] for z in command.split("-")]),
+        default="".join([z[:1] for z in new_tool.name.split("-")]),
         filter=lambda r: r or None,
     ).execute()
 
@@ -92,10 +93,10 @@ def main(*_):
         _replace_variables(
             os.path.join(configuration.custom_tools_path, new_tool.action, "README.md"),
             "{{tool}}",
-            new_tool.long_name or command,
+            new_tool.long_name or new_tool.name,
         )
 
-    configuration.add_tool(command, new_tool)
+    configuration.add_tool(new_tool)
     configuration.save()
 
 

--- a/tests/cli/test_tracer.py
+++ b/tests/cli/test_tracer.py
@@ -1,10 +1,15 @@
 import pytest
 
+from hexagon.domain.tool import Tool
+from hexagon.domain.env import Env
 from hexagon.support.tracer import Tracer
 
-tools_dict = {"docker": {"alias": "d"}, "bastion": {"alias": "b"}}
+tools_dict = [
+    Tool(name="docker", alias="d", action="docker"),
+    Tool(name="bastion", alias="b", action="sarasa"),
+]
 
-envs_dict = {"dev": {"alias": "d"}, "qa": {"alias": "q"}}
+envs_dict = [Env(name="dev", alias="d"), Env(name="qa", alias="q")]
 
 
 @pytest.mark.parametrize(
@@ -20,3 +25,29 @@ def test_build_command_from_initial_trace(initial, expected_command):
     tracer = Tracer(initial)
     assert tracer.command() == expected_command
     assert tracer.command_as_aliases(tools_dict, envs_dict) == expected_command
+
+
+@pytest.mark.parametrize(
+    "initial,traced,has_traced,expected_command,expected_alias",
+    [
+        ([], [], False, "", ""),
+        ([""], [""], False, "", ""),
+        (["docker"], ["docker"], False, "docker", "d"),
+        (
+            ["docker", "dev"],
+            ["docker", "dev", "something"],
+            True,
+            "docker dev something",
+            "d d something",
+        ),
+    ],
+)
+def test_build_command_from_traced(
+    initial, traced, has_traced, expected_command, expected_alias
+):
+    tracer = Tracer(initial)
+    for t in traced:
+        tracer.tracing(t)
+    assert tracer.has_traced() == has_traced
+    assert tracer.command() == expected_command
+    assert tracer.command_as_aliases(tools_dict, envs_dict) == expected_alias

--- a/tests/cli/test_wax.py
+++ b/tests/cli/test_wax.py
@@ -3,7 +3,7 @@ from InquirerPy import inquirer
 
 from hexagon.domain.tool import Tool
 from hexagon.domain.env import Env
-from hexagon.support.wax import search_by_key_or_alias, select_tool, select_env
+from hexagon.support.wax import search_by_name_or_alias, select_tool, select_env
 
 
 def inquirer_mock(ret):
@@ -32,13 +32,13 @@ def env_mock():
     return inquirer_mock("dev")
 
 
-tools_dict = {
-    "docker": Tool(alias="d", action="docker_run"),
-    "bastion": Tool(alias="b", action="bastion"),
-    "no_alias": Tool(action="some_action"),
-}
+tools_dict = [
+    Tool(name="docker", alias="d", action="docker_run"),
+    Tool(name="bastion", alias="b", action="bastion"),
+    Tool(name="no_alias", action="some_action"),
+]
 
-envs_dict = {"dev": Env(alias="d"), "qa": Env(alias="q")}
+envs_dict = [Env(name="dev", alias="d"), Env(name="qa", alias="q")]
 
 
 @pytest.mark.parametrize(
@@ -54,20 +54,23 @@ envs_dict = {"dev": Env(alias="d"), "qa": Env(alias="q")}
     ],
 )
 def test_search_tools_dict_by_key_or_alias(search, expected):
-    assert search_by_key_or_alias(tools_dict, search) == expected
+    assert search_by_name_or_alias(tools_dict, search) == expected
 
 
 def test_tool_is_selected_from_cmd():
     assert select_tool(tools_dict, "docker") == (
         "docker",
-        Tool(alias="d", action="docker_run"),
+        Tool(name="docker", alias="d", action="docker_run"),
     )
 
 
 def test_tool_is_selected_by_prompt(monkeypatch, tool_mock):
     monkeypatch.setattr(inquirer, "fuzzy", tool_mock)
 
-    assert select_tool(tools_dict) == ("docker", Tool(alias="d", action="docker_run"))
+    assert select_tool(tools_dict) == (
+        "docker",
+        Tool(name="docker", alias="d", action="docker_run"),
+    )
     assert tool_mock.args[0] == "Hi, which tool would you like to use today?"
     assert tool_mock.args[1] == [
         {"value": "docker", "name": "  docker"},


### PR DESCRIPTION
Me parece que sería mejor manejar tools y envs como listas en lugar de dicts, principalmente no me gustaba que estemos moviendo por todo el código un `Dict[str, Tool]`.

Creo que muchos partes se podrían optimizar manejandolo de esta manera (select_tool, select_env). También se nos simplificaría si en algún momento queremos traer las tools de un lugar remoto (ej: http), y creo que para el sorting nos va a venir bien también.
La funcionalidad de separator que estaba por ahí escondida ahora funcionaría si problemas (antes tenías que jugar con que el nombre tenga prefijo `__separator` para que no te los pise) 😄 
![image](https://user-images.githubusercontent.com/11464844/125202206-fa4ff980-e248-11eb-8532-4a28c81cc7b5.png)


Otra opción sería dejar el yaml como key-value e internamente mapear a Tool, y Env. Pero no le veo mucho sentido siendo que todavía podemos hacer breaking changes.