### PR TITLE
feat(yaml): show a more precise error to users

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,9 +32,13 @@ jobs:
           python -m pip install pytest
           python -m pip install -e .
 
-      - name: Test with pytest
+      - name: Unit tests
         run: |
-          pytest -svv
+          pytest -svv tests/
+
+      - name: e2e tests
+        run: |
+          pytest -svv e2e/
 
   release:
     if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}

--- a/e2e/tests/validate_yaml.py
+++ b/e2e/tests/validate_yaml.py
@@ -9,11 +9,22 @@ def test_show_errors_when_invalid_yaml():
             [
                 "There were 3 error(s) in your YAML",
                 "",
-                "cli.command -> field required",
+                "cli.command -> str type expected",
+                "2   name: Test",
+                "3   custom_tools_dir: .",
+                "4   command: [ 'test' ]",
+                "5",
+                "6 tools:",
                 "",
-                "envs -> field required",
+                "" "envs -> field required",
                 "",
-                "tools.0.action -> field required",
+                "",
+                "tools.1.action -> field required",
+                "13",
+                "14",
+                "15   - name: google-invalid",
+                "16     long_name: Google",
+                "17     type: web",
             ]
         )
         .exit(status=1)

--- a/e2e/tests/validate_yaml.py
+++ b/e2e/tests/validate_yaml.py
@@ -7,14 +7,13 @@ def test_show_errors_when_invalid_yaml():
         .run_hexagon()
         .then_output_should_be(
             [
-                "There was an error validating your YAML",
-                "3 validation errors for ConfigFile",
-                "cli -> command",
-                "field required (type=value_error.missing)",
-                "envs",
-                "field required (type=value_error.missing)",
-                "tools -> google-invalid -> action",
-                "field required (type=value_error.missing)",
+                "There were 3 error(s) in your YAML",
+                "",
+                "cli.command -> field required",
+                "",
+                "envs -> field required",
+                "",
+                "tools.google-invalid.action -> field required",
             ]
         )
         .exit(status=1)

--- a/e2e/validate_yaml/app.yml
+++ b/e2e/validate_yaml/app.yml
@@ -1,11 +1,9 @@
-cli: 
+cli:
   name: Test
   custom_tools_dir: .
+  command: [ 'test' ]
 
 tools:
-  - name: google-invalid
-    long_name: Google
-    type: web
 
   - name: google-valid
     long_name: Google
@@ -13,3 +11,7 @@ tools:
     action: 'open_link'
     envs:
       '*': https://www.google.com/
+
+  - name: google-invalid
+    long_name: Google
+    type: web

--- a/hexagon/domain/configuration.py
+++ b/hexagon/domain/configuration.py
@@ -8,7 +8,6 @@ from ruamel.yaml import YAML
 from hexagon.domain.cli import Cli
 from hexagon.domain.env import Env
 from hexagon.domain.tool import Tool, ToolType
-from hexagon.support.printer import log
 from hexagon.support.yaml import display_yaml_errors
 
 

--- a/hexagon/domain/configuration.py
+++ b/hexagon/domain/configuration.py
@@ -9,6 +9,7 @@ from hexagon.domain.cli import Cli
 from hexagon.domain.env import Env
 from hexagon.domain.tool import Tool, ToolType
 from hexagon.support.printer import log
+from hexagon.support.yaml import display_yaml_errors
 
 
 class ConfigFile(BaseModel):
@@ -43,17 +44,15 @@ class Configuration:
         self.project_path = os.path.dirname(self.project_yaml)
 
         try:
-            with open(path, "r") as f:
-                self.__yaml = YAML().load(f)
-                self.__config = ConfigFile(**self.__yaml)
+            self.__yaml = YAML().load(open(path, "r"))
+            self.__config = ConfigFile(**self.__yaml)
 
-                if self.__config.cli.custom_tools_dir:
-                    self.__register_custom_tools_path()
-
+            if self.__config.cli.custom_tools_dir:
+                self.__register_custom_tools_path()
         except FileNotFoundError:
             return self.__initial_setup_config()
         except ValidationError as errors:
-            log.error("There was an error validating your YAML", errors)
+            display_yaml_errors(errors, self.__yaml, self.project_yaml)
             sys.exit(1)
 
         return (

--- a/hexagon/support/printer/logger.py
+++ b/hexagon/support/printer/logger.py
@@ -33,23 +33,23 @@ class Logger:
     def example(
         self,
         *message: Union[str, Syntax],
-        decorator_start=True,
-        decorator_end=True,
+        decorator_start: Union[str, bool] = True,
+        decorator_end: Union[str, bool] = True,
     ):
         def __use_decorator(param, default):
             return param if isinstance(param, str) else default
 
-        if not self.__decorations.result_only and decorator_start:
+        if not self.__decorations.result_only and decorator_start is not False:
             self.__console.print(
-                f"{__use_decorator(decorator_start, self.__decorations.process_out)}\n"
+                __use_decorator(decorator_start, f"{self.__decorations.process_out}\n")
             )
 
         for msg in message:
             self.__console.print(msg)
 
-        if not self.__decorations.result_only and decorator_end:
+        if not self.__decorations.result_only and decorator_end is not False:
             self.__console.print(
-                f"\n{__use_decorator(decorator_end, self.__decorations.process_in)}"
+                __use_decorator(decorator_end, f"\n{self.__decorations.process_in}")
             )
 
     def error(self, message: str, err: Optional[Exception] = None):

--- a/hexagon/support/printer/logger.py
+++ b/hexagon/support/printer/logger.py
@@ -1,6 +1,7 @@
-from typing import Optional
+from typing import Optional, Union
 
 from rich.console import Console
+from rich.syntax import Syntax
 
 from hexagon.support.printer.themes import LoggingTheme
 
@@ -29,15 +30,27 @@ class Logger:
     def result(self, message: str):
         self.__console.print(f"{self.__decorations.border_result}{message}")
 
-    def example(self, *message: str):
-        if not self.__decorations.result_only:
-            self.__console.print(f"{self.__decorations.process_out}\n")
+    def example(
+        self,
+        *message: Union[str, Syntax],
+        decorator_start=True,
+        decorator_end=True,
+    ):
+        def __use_decorator(param, default):
+            return param if isinstance(param, str) else default
+
+        if not self.__decorations.result_only and decorator_start:
+            self.__console.print(
+                f"{__use_decorator(decorator_start, self.__decorations.process_out)}\n"
+            )
 
         for msg in message:
             self.__console.print(msg)
 
-        if not self.__decorations.result_only:
-            self.__console.print(f"\n{self.__decorations.process_in}")
+        if not self.__decorations.result_only and decorator_end:
+            self.__console.print(
+                f"\n{__use_decorator(decorator_end, self.__decorations.process_in)}"
+            )
 
     def error(self, message: str, err: Optional[Exception] = None):
         self.__console.print(f"[red]{message}")

--- a/hexagon/support/yaml/__init__.py
+++ b/hexagon/support/yaml/__init__.py
@@ -10,7 +10,9 @@ def display_yaml_errors(errors: ValidationError, ruamel_yaml, yaml_path):
     log.error(f"There were {len(errors_as_dict)} error(s) in your YAML")
     for err in errors_as_dict:
         (start, line_number, end) = __lines_of_error(err, ruamel_yaml)
-        log.error(f"\n✗ [bold]{'.'.join(err['loc'])}[/bold] -> {err['msg']}")
+        log.error(
+            f"\n✗ [u][bold]{'.'.join(map(lambda i: str(i), err['loc']))}[/bold] -> {err['msg']}"
+        )
         log.example(
             Syntax(
                 "\n".join(yml.splitlines()[start:end]),
@@ -25,14 +27,31 @@ def display_yaml_errors(errors: ValidationError, ruamel_yaml, yaml_path):
 
 def __lines_of_error(err, ruamel_yaml):
     line_number = __yaml_line_number(ruamel_yaml, err["loc"])
-    return line_number - (2 if line_number > 1 else 1), line_number, line_number + 4
+    return (
+        max(0, line_number - 3),
+        line_number,
+        line_number + 2 if line_number != 0 else line_number,
+    )
 
 
-def __yaml_line_number(yml, loc):
+def __yaml_line_number(yml, loc: list, line_count_hack: int = 0):
+    """
+    Get line number of location by accessing YAML metadata
+
+    :param yml: a dict representing de YAML, usually created with YAML().load(file)
+    :param loc: a list of the keys in the YAML
+    :param line_count_hack: a counter to indicate nested level,
+    for some reason ruamel .lc returns one less line_number for each level
+    :return: the line number of loc
+    """
     if len(loc) == 1:
         try:
-            return yml[loc[0]].lc.line
+            return line_count_hack + yml[loc[0]].lc.line
         except (LookupError, TypeError):
-            return yml.lc.line
+            return (
+                line_count_hack - 1 if line_count_hack > 0 else line_count_hack
+            ) + yml.lc.line
     else:
-        return __yaml_line_number(yml[loc[0]], loc[1:])
+        return __yaml_line_number(
+            yml[loc[0]], loc[1:], line_count_hack=line_count_hack + 1
+        )

--- a/hexagon/support/yaml/__init__.py
+++ b/hexagon/support/yaml/__init__.py
@@ -1,0 +1,38 @@
+from pydantic import ValidationError
+from rich.syntax import Syntax
+
+from hexagon.support.printer import log
+
+
+def display_yaml_errors(errors: ValidationError, ruamel_yaml, yaml_path):
+    yml = open(yaml_path, "r").read()
+    errors_as_dict = errors.errors()
+    log.error(f"There were {len(errors_as_dict)} error(s) in your YAML")
+    for err in errors_as_dict:
+        (start, line_number, end) = __lines_of_error(err, ruamel_yaml)
+        log.error(f"\n✗ [bold]{'.'.join(err['loc'])}[/bold] -> {err['msg']}")
+        log.example(
+            Syntax(
+                "\n".join(yml.splitlines()[start:end]),
+                "yaml",
+                line_numbers=True,
+                start_line=start + 1,
+            ),
+            decorator_start=False,
+            decorator_end=False,
+        )
+
+
+def __lines_of_error(err, ruamel_yaml):
+    line_number = __yaml_line_number(ruamel_yaml, err["loc"])
+    return line_number - (2 if line_number > 1 else 1), line_number, line_number + 4
+
+
+def __yaml_line_number(yml, loc):
+    if len(loc) == 1:
+        try:
+            return yml[loc[0]].lc.line
+        except (LookupError, TypeError):
+            return yml.lc.line
+    else:
+        return __yaml_line_number(yml[loc[0]], loc[1:])


### PR DESCRIPTION
closes #20

- [x] emprolijar el uso de decorators en `log.example`
- [x] tests e2e

El usuario vería los errores así:
![image](https://user-images.githubusercontent.com/11464844/125297059-478da300-e2fd-11eb-8b92-5ea18cc6fc43.png)
