### PR TITLE
fix(execute): use subprocess shell=True

### DIFF
--- a/e2e/execute_tool/app.yml
+++ b/e2e/execute_tool/app.yml
@@ -71,6 +71,15 @@ tools:
     alias: gc
     long_name: A generic command
 
+  - name: generic-multiline-command
+    action: |
+      echo "executed generic-multiline-command #1"
+      echo "executed generic-multiline-command #2"
+      echo "executed generic-multiline-command #3"
+    type: shell
+    alias: gc
+    long_name: A generic command
+
   - name: failing-command
     action: i-dont-exist
     type: shell

--- a/e2e/execute_tool/app.yml
+++ b/e2e/execute_tool/app.yml
@@ -71,13 +71,19 @@ tools:
     alias: gc
     long_name: A generic command
 
+  - name: complex-command
+    action: 'echo "nested $(echo 1)"'
+    type: shell
+    alias: cc
+    long_name: A complex command
+
   - name: generic-multiline-command
     action: |
       echo "executed generic-multiline-command #1"
       echo "executed generic-multiline-command #2"
       echo "executed generic-multiline-command #3"
     type: shell
-    alias: gc
+    alias: gmc
     long_name: A generic command
 
   - name: failing-command

--- a/e2e/tests/execute_tool.py
+++ b/e2e/tests/execute_tool.py
@@ -281,14 +281,35 @@ def test_execute_command():
     )
 
 
+def test_execute_multiline_command():
+    (
+        as_a_user(__file__)
+        .run_hexagon(["generic-multiline-command"])
+        .then_output_should_be(
+            [
+                "executed generic-multiline-command #1",
+                "executed generic-multiline-command #2",
+                "executed generic-multiline-command #3",
+            ]
+        )
+        .exit()
+    )
+    assert_file_has_contents(
+        __file__,
+        ".config/test/last-command.txt",
+        "hexagon-test generic-multiline-command",
+    )
+
+
 def test_execute_failing_command():
     (
         as_a_user(__file__)
         .run_hexagon(["failing-command"], {"HEXAGON_THEME": "default"})
         .then_output_should_be(
             [
-                "i-dont-exist failed with: [Errno 2] No such file or directory: 'i-dont-exist'",
-                "We tried looking for:",
+                "i-dont-exist returned code: 127",
+                "Hexagon couldn't execute the action: i-dont-exist",
+                "We tried:",
             ],
             True,
         )

--- a/e2e/tests/execute_tool.py
+++ b/e2e/tests/execute_tool.py
@@ -281,6 +281,18 @@ def test_execute_command():
     )
 
 
+def test_execute_complex_command():
+    (
+        as_a_user(__file__)
+        .run_hexagon(["complex-command"])
+        .then_output_should_be(["nested 1"])
+        .exit()
+    )
+    assert_file_has_contents(
+        __file__, ".config/test/last-command.txt", "hexagon-test complex-command"
+    )
+
+
 def test_execute_multiline_command():
     (
         as_a_user(__file__)


### PR DESCRIPTION
execute commands spawning an intermediate shell process (shell=True) for a more native experience. Also use sh instead of bash as default shell

fixes #37

Multiline commands are now posible:
```yaml
  - name: generic-multiline-command
    action: |
      echo "executed generic-multiline-command #1"
      echo "executed generic-multiline-command #2"
      echo "executed generic-multiline-command #3"
    type: shell
    alias: gc
    long_name: A generic command
```

Inline scripts are now posible:
```yaml
  - name: generic-multiline-command
    action: |
      #!/usr/bin/env zsh
      echo "hola"
      docker rm -f $(docker container ls --filter "status=exited" -q)
    type: shell
    alias: gc
    long_name: A generic command
```

Changed error message a bit:
![image](https://user-images.githubusercontent.com/11464844/126239768-666d59c7-4077-4bbd-a44c-8f2a75f8addf.png)
