### PR TITLE
fix: added packaging to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
         "requests",
         "ruamel.yaml",
         "pydantic",
+        "packaging",
     ],
     python_requires=">=3.7",
     entry_points="""


### PR DESCRIPTION
Sigue roto el auto-update, esta vez porque no esta incluido `packaging` en las dependencias, lo sumo.