### PR TITLE
feat: options by env variables, local options file or defaults

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,6 +65,23 @@
                 "HEXAGON_STORAGE_PATH": "${workspaceFolder}/e2e/update_cli/storage",
                 "HEXAGON_TEST_SHELL": "HEXAGON_TEST_SHELL"
             }
+        },
+        {
+            "name": "Options",
+            "type": "python",
+            "request": "launch",
+            "module": "hexagon",
+            "console": "integratedTerminal",
+            "subProcess": true,
+            "args": [
+                "print-options"
+            ],
+            "env": {
+                "HEXAGON_CONFIG_FILE": "${workspaceFolder}/e2e/options/app.yml",
+                "HEXAGON_STORAGE_PATH": "${workspaceFolder}/e2e/options/storage",
+                "HEXAGON_TEST_SHELL": "HEXAGON_TEST_SHELL",
+                "HEXAGON_UPDATE_DISABLED": "1"
+            }
         }
     ]
 }

--- a/e2e/options/app.yml
+++ b/e2e/options/app.yml
@@ -1,0 +1,9 @@
+cli:
+  name: Test
+  command: hexagon-test
+  custom_tools_dir: .
+tools:
+  - name: print-options
+    action: hexagon.actions.internal.get_options
+    type: hexagon
+envs: []

--- a/e2e/tests/options.py
+++ b/e2e/tests/options.py
@@ -1,0 +1,91 @@
+from ruamel.yaml.main import YAML
+from hexagon.support.storage import HEXAGON_STORAGE_APP, HexagonStorageKeys
+from e2e.tests.utils.hexagon_spec import as_a_user
+from e2e.tests.utils.path import e2e_test_folder_path
+import os
+import shutil
+import pytest
+from pathlib import Path
+
+storage_path = os.path.join(e2e_test_folder_path(__file__), "storage")
+base_env_vars = {"HEXAGON_THEME": "default", "HEXAGON_STORAGE_PATH": storage_path}
+local_options = {"update": {"time_between_checks": "2 0:00:00"}}
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    if os.path.exists(storage_path):
+        shutil.rmtree(storage_path)
+    Path(storage_path).mkdir(exist_ok=True, parents=True)
+
+
+def _write_local_options(options):
+    file_path = (
+        os.path.join(
+            storage_path, HEXAGON_STORAGE_APP, HexagonStorageKeys.options.value
+        )
+        + ".yaml"
+    )
+    Path(os.path.dirname(file_path)).mkdir(exist_ok=True, parents=True)
+    with open(file_path, "w") as file:
+        YAML().dump(options, file)
+
+
+def test_default_options():
+    (
+        as_a_user(__file__)
+        .run_hexagon(["print-options"], base_env_vars)
+        .then_output_should_be(
+            ["update", "  time_between_checks: 1 day, 0:00:00"], True
+        )
+        .exit()
+    )
+
+
+def test_local_options():
+    _write_local_options(local_options)
+
+    (
+        as_a_user(__file__)
+        .run_hexagon(["print-options"], base_env_vars)
+        .then_output_should_be(
+            ["update", "  time_between_checks: 2 days, 0:00:00"], True
+        )
+        .exit()
+    )
+
+
+def test_env_variable():
+    _write_local_options(local_options)
+
+    (
+        as_a_user(__file__)
+        .run_hexagon(
+            ["print-options"],
+            {**base_env_vars, "HEXAGON_UPDATE_TIME_BETWEEN_CHECKS": "3 0:00:00"},
+        )
+        .then_output_should_be(
+            ["update", "  time_between_checks: 3 days, 0:00:00"], True
+        )
+        .exit()
+    )
+
+
+def test_invalid_local_options():
+    _write_local_options({"update": {"time_between_checks": "SARLANGA"}})
+
+    (
+        as_a_user(__file__)
+        .run_hexagon(
+            ["print-options"],
+            base_env_vars,
+        )
+        .then_output_should_be(
+            [
+                "1 validation error for Options",
+                "update -> time_between_checks",
+                "  invalid duration format (type=value_error.duration)",
+            ]
+        )
+        .exit(1)
+    )

--- a/hexagon/__main__.py
+++ b/hexagon/__main__.py
@@ -3,6 +3,7 @@ import sys
 
 from hexagon.support.args import fill_args
 from hexagon.domain import cli, tools, envs
+from hexagon.domain.options import load_hexagon_options
 from hexagon.support.execute_tool import execute_action
 from hexagon.support.help import print_help
 from hexagon.support.tracer import tracer
@@ -10,8 +11,10 @@ from hexagon.support.wax import search_by_name_or_alias, select_env, select_tool
 from hexagon.support.printer import log
 from hexagon.support.update.hexagon import check_for_hexagon_updates
 from hexagon.support.storage import (
+    HEXAGON_STORAGE_APP,
     HexagonStorageKeys,
     store_user_data,
+    load_user_data,
 )
 
 
@@ -20,6 +23,10 @@ def main():
 
     if _tool == "-h" or _tool == "--help":
         return print_help(cli, tools, envs)
+
+    load_hexagon_options(
+        {}, load_user_data(HexagonStorageKeys.options.value, HEXAGON_STORAGE_APP)
+    )
 
     log.start(f"[bold]{cli.name}")
     log.gap()

--- a/hexagon/actions/internal/get_options.py
+++ b/hexagon/actions/internal/get_options.py
@@ -1,0 +1,17 @@
+from datetime import timedelta
+from typing import Any, Dict
+from hexagon.domain import get_options
+from hexagon.support.printer import log
+
+
+def _print_dict_indented(dictionary: Dict[str, Any], indent_level=0):
+    for key, value in dictionary.items():
+        if isinstance(value, (str, int, float, timedelta)):
+            log.info(" " * indent_level * 2 + f"{key}: {value}")
+        else:
+            log.info(key)
+            _print_dict_indented(value.__dict__, indent_level + 1)
+
+
+def main(*_):
+    _print_dict_indented(get_options().__dict__)

--- a/hexagon/domain/__init__.py
+++ b/hexagon/domain/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 from .configuration import Configuration
+from .options import get_hexagon_options
 
 CONFIG_FILE_ENV_VARIABLE_NAME = "HEXAGON_CONFIG_FILE"
 
@@ -9,3 +10,4 @@ configuration = Configuration()
 cli, tools, envs = configuration.init_config(
     os.getenv(CONFIG_FILE_ENV_VARIABLE_NAME, "app.yaml")
 )
+get_options = get_hexagon_options

--- a/hexagon/domain/options/__init__.py
+++ b/hexagon/domain/options/__init__.py
@@ -1,0 +1,100 @@
+from typing import Any, Dict, List
+
+from pydantic.error_wrappers import ValidationError
+from .update import (
+    UpdateOptions,
+    update_options_keys,
+    default_update_options,
+)
+from pydantic import BaseModel
+import os
+import sys
+from hexagon.support.printer import log
+
+
+class Options(BaseModel):
+    update: UpdateOptions
+
+
+OptionsKeysMapLeaf = Dict[str, str]
+OptionsKeysMapBranch = Dict[str, OptionsKeysMapLeaf]
+OptionsKeysMap = Dict[str, OptionsKeysMapBranch or OptionsKeysMapLeaf]
+
+options_keys_map: OptionsKeysMap = {"update": update_options_keys}
+defaults = {"update": default_update_options}
+options = None
+
+
+def _flatten_option_leafs_with_dot_notation(options_keys_map: OptionsKeysMap):
+    leafs: List[str] = []
+    for key, value in options_keys_map.items():
+        if isinstance(value, list):
+            for val in value:
+                leafs.append(f"{key}.{val}")
+        elif isinstance(value, dict):
+            leafs.extend(_flatten_option_leafs_with_dot_notation(value))
+    return leafs
+
+
+def _get_first_and_other_keys_from_dot_notation(key: str or List[str]):
+    if isinstance(key, str):
+        key = key.split(".")
+    return key[0] if len(key) > 0 else None, key[1:]
+
+
+def _access_dict_with_dot_notation(dictionary: Dict[str, Any], key: str):
+    first_key, other_keys = _get_first_and_other_keys_from_dot_notation(key)
+
+    if first_key not in dictionary:
+        return None
+    next_value = dictionary[first_key]
+    if len(other_keys) == 0:
+        return next_value
+    else:
+        return _access_dict_with_dot_notation(next_value, other_keys)
+
+
+def _write_dict_with_dot_notation(dictionary: Dict[str, Any], key: str, value: Any):
+    first_key, other_keys = _get_first_and_other_keys_from_dot_notation(key)
+
+    if len(other_keys) == 0:
+        dictionary[first_key] = value
+    else:
+        if first_key not in dictionary:
+            dictionary[first_key] = {}
+        _write_dict_with_dot_notation(dictionary[first_key], other_keys, value)
+
+
+def load_hexagon_options(
+    cli_options: Dict[str, str], local_options: Dict[str, Any]
+) -> Options:
+    global options
+    flattened_keys = _flatten_option_leafs_with_dot_notation(options_keys_map)
+    opt = {}
+
+    for key in flattened_keys:
+        candidate = cli_options[key] if key in cli_options else None
+
+        if not candidate:
+            candidate = os.getenv("HEXAGON_" + key.replace(".", "_").upper())
+        if not candidate and local_options:
+            candidate = _access_dict_with_dot_notation(local_options, key)
+        if not candidate:
+            first_key, _ = _get_first_and_other_keys_from_dot_notation(key)
+            candidate = defaults[first_key] if first_key in defaults else None
+            if candidate:
+                opt[first_key] = candidate
+                continue
+
+        _write_dict_with_dot_notation(opt, key, candidate)
+
+    try:
+        options = Options(**opt)
+    except ValidationError as errors:
+        log.error(str(errors))
+        sys.exit(1)
+
+
+def get_hexagon_options():
+    global options
+    return options

--- a/hexagon/domain/options/update.py
+++ b/hexagon/domain/options/update.py
@@ -1,0 +1,10 @@
+import datetime
+from pydantic.main import BaseModel
+
+
+class UpdateOptions(BaseModel):
+    time_between_checks: datetime.timedelta
+
+
+update_options_keys = ["time_between_checks"]
+default_update_options = UpdateOptions(time_between_checks=datetime.timedelta(days=1))

--- a/hexagon/support/storage.py
+++ b/hexagon/support/storage.py
@@ -1,3 +1,4 @@
+from hexagon.utils.dict import merge_dictionaries_deep
 import os
 from pathlib import Path
 import sys
@@ -11,6 +12,7 @@ HEXAGON_STORAGE_APP = "hexagon"
 
 
 class HexagonStorageKeys(Enum):
+    options = "options"
     last_command = "last-command"
     last_update_check = "last-update-check"
 
@@ -37,23 +39,6 @@ _storage_path_by_os = {
 _storage_dir_path = None
 
 InputDataType = str or List[str] or Dict[Any]
-
-
-def _merge_dictionaries_deep(a, b, path=None):
-    """merges b into a"""
-    if path is None:
-        path = []
-    for key in b:
-        if key in a:
-            if isinstance(a[key], dict) and isinstance(b[key], dict):
-                _merge_dictionaries_deep(a[key], b[key], path + [str(key)])
-            elif a[key] == b[key]:
-                pass
-            else:
-                a[key] = b[key]
-        else:
-            a[key] = b[key]
-    return a
 
 
 def _get_storage_dir_path():
@@ -145,7 +130,7 @@ def store_user_data(key: str, data: InputDataType, append=False, app: str = None
             with open(file_path, "r") as file:
                 previous = YAML().load(file)
 
-        to_write = _merge_dictionaries_deep(previous, data) if previous else data
+        to_write = merge_dictionaries_deep(previous, data) if previous else data
 
         with open(file_path, "w") as file:
             YAML().dump(to_write, file)

--- a/hexagon/support/update/shared.py
+++ b/hexagon/support/update/shared.py
@@ -1,4 +1,5 @@
 from hexagon.support.storage import HexagonStorageKeys, load_user_data, store_user_data
+from hexagon.domain import get_options
 import datetime
 
 LAST_UPDATE_DATE_FORMAT = "%Y%m%d"
@@ -12,11 +13,12 @@ def already_checked_for_updates(app: str = None) -> bool:
     if last_checked:
         last_checked_date = datetime.datetime.strptime(
             last_checked, LAST_UPDATE_DATE_FORMAT
-        ).date()
+        )
 
-        # TODO: Move to hexagon configuration
-        # See https://github.com/redbeestudios/hexagon/pull/35#discussion_r670870804 for more information
-        result = last_checked_date >= datetime.date.today()
+        result = (
+            last_checked_date + get_options().update.time_between_checks
+            >= datetime.datetime.now()
+        )
 
     if not result:
         store_user_data(

--- a/hexagon/utils/dict.py
+++ b/hexagon/utils/dict.py
@@ -1,0 +1,15 @@
+def merge_dictionaries_deep(a: dict, b: dict, path=None):
+    """merges b into a"""
+    if path is None:
+        path = []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                merge_dictionaries_deep(a[key], b[key], path + [str(key)])
+            elif a[key] == b[key]:
+                pass
+            else:
+                a[key] = b[key]
+        else:
+            a[key] = b[key]
+    return a


### PR DESCRIPTION
Opciones para hexagon.

Las fuentes de opciones son, en orden de prioridad:

- Argumentos de cli (no implementado el input asi que no funciona)
- Variable de entorno
- Archivo local de configuracion (esta en `{HEAXGON_STORAGE_PATH}/hexagon/options.yaml`, como follow up a esto podemos hacer alguna forma de editarlas desde hexagon, ahora mismo no hay forma práctica de editarlo aunque sí se puede documentar)
- Defaults (hardcodeadas en hexagon)

La opción que hay ahora por ejemplo: `update.time_between_checks` (notese que es un ejemplo feo porque es un `timedelta` el valor y se usa el formato soportado por pydantic para definir el timedelta)

Como variable de entorno:
```
HEXAGON_UPDATE_TIME_BETWEEN_CHECKS="3 0:00:00"
```

Como archivo local de configuracion:
```yaml
update:
  time_between_checks: 2 0:00:00
```

Default:
```python
datetime.timedelta(days=1)
```

Para usar el valor, dentro de cualquier módulo interno de hexagon:
```python
from hexagon.domain import get_options

get_options().update.time_between_checks
```

El e2e lo hice haciendo una action interna no expuesta al usuario final llamada `get_options`. La idea era a) simplificarme la vida para hacer la prueba e2e. b) empezar a tener en cuenta que hexagon pueda exponer apis internas como esta de opciones para tener un protocolo de comunicación con implementaciones de presentación de hexagon avanzadas (e.g. Hexagon UI). La acción en cuestión no esta optimizada para comunicación efectiva con otra máquina, sino para lectura humana, pero todavía no hay un protocolo ideal definido por lo que no me puse a preocuparme por eso. Igualmente se puede usar un theme para variar entre legible por humanos y facilmente deserializable.

PD: Demasiada recursividad en este PR es todo árboles prácticamente.