### PR TITLE
feat(i18n): mapped translation string + CI

### DIFF
--- a/.github/i18n-problem-matcher.json
+++ b/.github/i18n-problem-matcher.json
@@ -1,0 +1,15 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "hexagon-i18n",
+      "pattern": [
+        {
+          "regexp": "^([^:]*):(\\d+):msgstr \"\":(.*)$",
+          "file": 1,
+          "line": 2,
+          "message": 3
+        }
+      ]
+    }
+  ]
+}

--- a/.github/i18n-problem-matcher.json
+++ b/.github/i18n-problem-matcher.json
@@ -4,7 +4,7 @@
       "owner": "hexagon-i18n",
       "pattern": [
         {
-          "regexp": "^([^:]*):(\\d+):msgstr \"\":(.*)$",
+          "regexp": "^([^:]*):(\\d+):(.*)$",
           "file": 1,
           "line": 2,
           "message": 3

--- a/.github/scripts/i18n/build.sh
+++ b/.github/scripts/i18n/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+pygettext3 -d hexagon -o locales/hexagon.pot hexagon
+for locale in locales/**/LC_MESSAGES/hexagon.po; do
+  l=$(echo "$locale" | cut -d/ -f2)
+  echo "merging messages to $locale"
+  msgmerge --update "$locale" locales/hexagon.pot
+  echo "formatting messages to $locale"
+  msgfmt -o "locales/$l/LC_MESSAGES/hexagon.mo" "$locale"
+done

--- a/.github/scripts/i18n/check.sh
+++ b/.github/scripts/i18n/check.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 for locale in locales/**/LC_MESSAGES/hexagon.po; do
-  grep -Hin 'msgstr ""' "$locale" >>errors.txt
+  (cat "$locale"; echo) \
+    | awk '/^msgstr ""$/{getline;print NR-1":"$0}' \
+    | awk -v fname="$locale" '/^[0-9]*:\s*$/{print fname":"$0"translation string should not be empty"}' >> errors.txt
 done
 
 if [ -s errors.txt ]; then
-  while IFS="" read -r p || [ -n "$p" ]; do
-    # the first match is always on line 6 and empty
-    if [[ "$p" != *".po:6:"* ]]; then printf '%s\n' "$p:translation string should not be empty"; fi
-  done <errors.txt
+  echo "Some translation files contain errors"
+  cat errors.txt
   exit 1
 else
   echo "🥳 all strings have a translation 🗺"

--- a/.github/scripts/i18n/check.sh
+++ b/.github/scripts/i18n/check.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+for locale in locales/**/LC_MESSAGES/hexagon.po; do
+  grep -Hin 'msgstr ""' "$locale" >>errors.txt
+done
+
+if [ -s errors.txt ]; then
+  while IFS="" read -r p || [ -n "$p" ]; do
+    # the first match is always on line 6 and empty
+    if [[ "$p" != *".po:6:"* ]]; then printf '%s\n' "$p:translation string should not be empty"; fi
+  done <errors.txt
+  exit 1
+else
+  echo "🥳 all strings have a translation 🗺"
+  exit 0
+fi

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,6 +56,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: install gettext
+        run: sudo apt-get install -y gettext
+
       - name: add matcher
         run: |
           echo "::add-matcher::.github/i18n-problem-matcher.json"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Setup e2e dependencies
         run: |
           python -m pip install wheel
+          .github/scripts/i18n/build.sh
           python setup.py sdist bdist_wheel
           python -m pip install --find-links=./dist hexagon
 
@@ -81,6 +82,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: build locales
+        run: .github/scripts/i18n/build.sh
 
       - name: Python Semantic Release
         uses: relekang/python-semantic-release@master

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,11 +45,58 @@ jobs:
         run: |
           pipenv run pytest -svv e2e/
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: hexagon
+          path: dist/*.tar.gz
+
+  i18n:
+    name: i18n
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: add matcher
+        run: |
+          echo "::add-matcher::.github/i18n-problem-matcher.json"
+
+      - name: build locales
+        run: |
+          pygettext3 -d hexagon -o locales/hexagon.pot hexagon
+          for locale in locales/**/LC_MESSAGES/hexagon.po ; do
+              l=$(echo "$locale" | cut -d/ -f2)
+              echo "merging messages to $locale"
+              msgmerge --update "$locale" locales/hexagon.pot
+              echo "formatting messages to $locale"
+              msgfmt -o "locales/$l/LC_MESSAGES/hexagon.mo" "$locale"
+          done
+
+      - name: validate translations
+        run: |
+          for locale in locales/**/LC_MESSAGES/hexagon.po; do
+            grep -Hin 'msgstr ""' "$locale" >>errors.txt
+          done
+
+          if [ -s errors.txt ]; then
+            while IFS="" read -r p || [ -n "$p" ]; do
+              # the first match is always empty
+              if [[ "$p" != *".po:6:"* ]]; then printf '%s\n' "$p:translation string should not be empty"; fi
+            done <errors.txt
+            exit 1
+          else
+            echo "all strings have a translation"
+            exit 0
+          fi
+
+      - name: remove matcher
+        run: |
+          echo "::remove-matcher owner=hexagon-i18n::"
+
   release:
     if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
 
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, i18n]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get install -y gettext
           python -m pip install --upgrade pipenv
           pipenv install --dev --ignore-pipfile
 
@@ -82,6 +83,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: install gettext
+        run: sudo apt-get install -y gettext
 
       - name: build locales
         run: .github/scripts/i18n/build.sh

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,40 +60,16 @@ jobs:
         run: sudo apt-get install -y gettext
 
       - name: add matcher
-        run: |
-          echo "::add-matcher::.github/i18n-problem-matcher.json"
+        run: echo "::add-matcher::.github/i18n-problem-matcher.json"
 
       - name: build locales
-        run: |
-          pygettext3 -d hexagon -o locales/hexagon.pot hexagon
-          for locale in locales/**/LC_MESSAGES/hexagon.po ; do
-              l=$(echo "$locale" | cut -d/ -f2)
-              echo "merging messages to $locale"
-              msgmerge --update "$locale" locales/hexagon.pot
-              echo "formatting messages to $locale"
-              msgfmt -o "locales/$l/LC_MESSAGES/hexagon.mo" "$locale"
-          done
+        run: .github/scripts/i18n/build.sh
 
       - name: validate translations
-        run: |
-          for locale in locales/**/LC_MESSAGES/hexagon.po; do
-            grep -Hin 'msgstr ""' "$locale" >>errors.txt
-          done
-
-          if [ -s errors.txt ]; then
-            while IFS="" read -r p || [ -n "$p" ]; do
-              # the first match is always empty
-              if [[ "$p" != *".po:6:"* ]]; then printf '%s\n' "$p:translation string should not be empty"; fi
-            done <errors.txt
-            exit 1
-          else
-            echo "all strings have a translation"
-            exit 0
-          fi
+        run: .github/scripts/i18n/check.sh
 
       - name: remove matcher
-        run: |
-          echo "::remove-matcher owner=hexagon-i18n::"
+        run: echo "::remove-matcher owner=hexagon-i18n::"
 
   release:
     if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: test & release
+name: ci/cd
 
 on:
   push:
@@ -41,14 +41,14 @@ jobs:
           python setup.py sdist bdist_wheel
           python -m pip install --find-links=./dist hexagon
 
-      - name: e2e tests
-        run: |
-          pipenv run pytest -svv e2e/
-
       - uses: actions/upload-artifact@v2
         with:
           name: hexagon
           path: dist/*.tar.gz
+
+      - name: e2e tests
+        run: |
+          pipenv run pytest -svv e2e/
 
   i18n:
     name: i18n

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ e2e/*/home-aliases.txt
 e2e/last-output.txt
 e2e/*/last_command
 
+**/**/*.mo
+
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,7 @@
   <component name="ProjectRootManager" version="2" languageLevel="JDK_16" project-jdk-name="Pipenv (hexagon)" project-jdk-type="Python SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
+  <component name="PythonCompatibilityInspectionAdvertiser">
+    <option name="version" value="3" />
+  </component>
 </project>

--- a/e2e/tests/create_new_tool.py
+++ b/e2e/tests/create_new_tool.py
@@ -28,7 +28,7 @@ def _shared_assertions(spec: HexagonSpec):
                 "",
                 "⦾ Google",
                 "",
-                "⬡ Save Last Command as Linux Alias",
+                "⬡ Save Last Command as Shell Alias",
                 "",
                 "⬡ Create A New Tool",
                 "",

--- a/e2e/tests/print_help.py
+++ b/e2e/tests/print_help.py
@@ -105,6 +105,6 @@ def test_print_help_using_yaml_contents_no_tools(command):
             }
         )
         .run_hexagon([command], os_env_vars={"HEXAGON_THEME": "disabled"})
-        .then_output_should_be(["Test", "", "Envs:", "", "", "Tools:", "", "",])
+        .then_output_should_be(["Test", "", "Envs:", "", "", "Tools:", "", ""])
         .exit()
     )

--- a/e2e/tests/print_help.py
+++ b/e2e/tests/print_help.py
@@ -81,7 +81,7 @@ def test_print_help_using_yaml_contents(command):
                 "",
                 "hexagon:",
                 "  save-alias                                                  Save Last Command",
-                "as Linux Alias",
+                "as Shell Alias",
                 "  create-tool                                                 Create A New Tool",
             ]
         )
@@ -105,17 +105,6 @@ def test_print_help_using_yaml_contents_no_tools(command):
             }
         )
         .run_hexagon([command], os_env_vars={"HEXAGON_THEME": "disabled"})
-        .then_output_should_be(
-            [
-                "Test",
-                "",
-                "Envs:",
-                "",
-                "",
-                "Tools:",
-                "",
-                "",
-            ]
-        )
+        .then_output_should_be(["Test", "", "Envs:", "", "", "Tools:", "", "",])
         .exit()
     )

--- a/e2e/tests/save_alias.py
+++ b/e2e/tests/save_alias.py
@@ -23,7 +23,7 @@ def test_save_alias():
         .input("hexagon-save-alias-test")
         .then_output_should_be(
             [
-                "Last command: hexagon-test python-module Alias name?",
+                "Alias name? hexagon-save-alias-test",
                 "# added by hexagon",
                 'alias hexagon-save-alias-test="hexagon-test python-module"',
                 "$ hexagon-save-alias-test",

--- a/e2e/tests/save_alias.py
+++ b/e2e/tests/save_alias.py
@@ -23,7 +23,6 @@ def test_save_alias():
         .input("hexagon-save-alias-test")
         .then_output_should_be(
             [
-                "Alias name? hexagon-save-alias-test",
                 "# added by hexagon",
                 'alias hexagon-save-alias-test="hexagon-test python-module"',
                 "$ hexagon-save-alias-test",

--- a/e2e/tests/update_hexagon.py
+++ b/e2e/tests/update_hexagon.py
@@ -8,7 +8,7 @@ LAST_UPDATE_DATE_FORMAT = "%Y%m%d"
 test_folder_path = e2e_test_folder_path(__file__)
 storage_path = os.path.realpath(os.path.join(test_folder_path, "storage"))
 last_checked_storage_path = os.path.join(
-    storage_path, "hexagon", "last-update-check.txt",
+    storage_path, "hexagon", "last-update-check.txt"
 )
 
 

--- a/e2e/tests/update_hexagon.py
+++ b/e2e/tests/update_hexagon.py
@@ -44,7 +44,7 @@ def test_new_hexagon_version_available():
 
     (
         as_a_user(__file__)
-        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars,)
+        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars)
         .write("n")
         .then_output_should_be(
             [["Would you like to update?", "No"]], discard_until_first_match=True
@@ -59,7 +59,7 @@ def test_prompt_to_update_hexagon_only_once():
 
     (
         as_a_user(__file__)
-        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars,)
+        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars)
         .write("n")
         .then_output_should_be(
             [["Would you like to update?", "No"]], discard_until_first_match=True
@@ -70,7 +70,7 @@ def test_prompt_to_update_hexagon_only_once():
 
     (
         as_a_user(__file__)
-        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars,)
+        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars)
         .then_output_should_be(["my-module"])
         .exit()
     )
@@ -81,7 +81,7 @@ def test_prompt_to_update_hexagon_once_a_day():
 
     (
         as_a_user(__file__)
-        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars,)
+        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars)
         .then_output_should_be(["my-module"])
         .exit()
     )
@@ -92,7 +92,7 @@ def test_prompt_to_update_hexagon_again_next_day():
 
     (
         as_a_user(__file__)
-        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars,)
+        .run_hexagon(["my-module"], os_env_vars=no_changelog_env_vars)
         .write("n")
         .then_output_should_be(
             [["Would you like to update?", "No"]], discard_until_first_match=True

--- a/e2e/tests/utils/run.py
+++ b/e2e/tests/utils/run.py
@@ -49,6 +49,9 @@ def run_hexagon_e2e_test(
     if "HEXAGON_SEND_TELEMETRY" not in os_env_vars:
         os_env_vars["HEXAGON_SEND_TELEMETRY"] = "0"
 
+    if "HEXAGON_LOCALES_DIR" not in os_env_vars:
+        os_env_vars["HEXAGON_LOCALES_DIR"] = os.path.join(hexagon_path, "locales")
+
     os.environ["HEXAGON_STORAGE_PATH"] = os_env_vars.get(
         "HEXAGON_STORAGE_PATH",
         os.getenv("HEXAGON_STORAGE_PATH", os.path.join(test_folder_path, ".config")),

--- a/e2e/tests/utils/run.py
+++ b/e2e/tests/utils/run.py
@@ -78,7 +78,7 @@ def run_hexagon(
 
     command = [*HEXAGON_COMMAND, *args]
     print(
-        f"\nrunning command:\n{' '.join([f'{k}={v}' for k,v in environment.items() if 'HEXAGON_' in k] + command)}"
+        f"\nrunning command:\n{' '.join([f'{k}={v}' for k,v in os_env_vars.items() if 'HEXAGON_' in k] + command)}"
     )
     return subprocess.Popen(
         command,

--- a/e2e/tests/utils/run.py
+++ b/e2e/tests/utils/run.py
@@ -52,9 +52,6 @@ def run_hexagon_e2e_test(
     if "HEXAGON_LOCALES_DIR" not in os_env_vars:
         os_env_vars["HEXAGON_LOCALES_DIR"] = os.path.join(hexagon_path, "locales")
 
-    if "LANGUAGE" not in os_env_vars:
-        os_env_vars["LANGUAGE"] = "en_US"
-
     os.environ["HEXAGON_STORAGE_PATH"] = os_env_vars.get(
         "HEXAGON_STORAGE_PATH",
         os.getenv("HEXAGON_STORAGE_PATH", os.path.join(test_folder_path, ".config")),
@@ -78,7 +75,7 @@ def run_hexagon(
 
     command = [*HEXAGON_COMMAND, *args]
     print(
-        f"\nrunning command:\n{' '.join([f'{k}={v}' for k,v in os_env_vars.items() if 'HEXAGON_' in k] + command)}"
+        f"\nrunning command:\n{' '.join([f'{k}={v}' for k,v in environment.items() if 'HEXAGON_' in k] + command)}"
     )
     return subprocess.Popen(
         command,

--- a/e2e/tests/utils/run.py
+++ b/e2e/tests/utils/run.py
@@ -77,12 +77,7 @@ def run_hexagon(
     print(
         f"\nrunning command:\n{' '.join([f'{k}={v}' for k,v in environment.items() if 'HEXAGON_' in k] + command)}"
     )
-    print(
-        environment["LANGUAGE"],
-        environment["LC_ALL"],
-        environment["LC_MESSAGES"],
-        environment["LANG"],
-    )
+    print("env", environment)
     return subprocess.Popen(
         command,
         stdout=subprocess.PIPE,

--- a/e2e/tests/utils/run.py
+++ b/e2e/tests/utils/run.py
@@ -77,7 +77,6 @@ def run_hexagon(
     print(
         f"\nrunning command:\n{' '.join([f'{k}={v}' for k,v in environment.items() if 'HEXAGON_' in k] + command)}"
     )
-    print("env", environment)
     return subprocess.Popen(
         command,
         stdout=subprocess.PIPE,

--- a/e2e/tests/utils/run.py
+++ b/e2e/tests/utils/run.py
@@ -77,6 +77,12 @@ def run_hexagon(
     print(
         f"\nrunning command:\n{' '.join([f'{k}={v}' for k,v in environment.items() if 'HEXAGON_' in k] + command)}"
     )
+    print(
+        environment["LANGUAGE"],
+        environment["LC_ALL"],
+        environment["LC_MESSAGES"],
+        environment["LANG"],
+    )
     return subprocess.Popen(
         command,
         stdout=subprocess.PIPE,

--- a/e2e/tests/utils/run.py
+++ b/e2e/tests/utils/run.py
@@ -52,6 +52,9 @@ def run_hexagon_e2e_test(
     if "HEXAGON_LOCALES_DIR" not in os_env_vars:
         os_env_vars["HEXAGON_LOCALES_DIR"] = os.path.join(hexagon_path, "locales")
 
+    if "LANGUAGE" not in os_env_vars:
+        os_env_vars["LANGUAGE"] = "en_US"
+
     os.environ["HEXAGON_STORAGE_PATH"] = os_env_vars.get(
         "HEXAGON_STORAGE_PATH",
         os.getenv("HEXAGON_STORAGE_PATH", os.path.join(test_folder_path, ".config")),

--- a/hexagon/__main__.py
+++ b/hexagon/__main__.py
@@ -7,7 +7,7 @@ from hexagon.support.args import fill_args
 from hexagon.domain import cli, tools, envs
 from hexagon.support.help import print_help
 from hexagon.support.tracer import tracer
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
 from hexagon.support.update.hexagon import check_for_hexagon_updates
 from hexagon.support.storage import (
     HexagonStorageKeys,
@@ -15,9 +15,11 @@ from hexagon.support.storage import (
 )
 from hexagon.plugins import collect_plugins
 
+_ = translator
+
 
 def main():
-    _, _tool, _env = fill_args(sys.argv, 3)
+    _u, _tool, _env = fill_args(sys.argv, 3)
 
     if _tool == "-h" or _tool == "--help":
         return print_help(cli, tools, envs)
@@ -32,9 +34,7 @@ def main():
 
     if cli.name == "Hexagon":
         log.info(
-            "This looks like your first time running Hexagon.",
-            'You should probably run "Install CLI".',
-            gap_end=1,
+            _("msg.main.first_time_intro"), _("msg.main.first_time_tool"), gap_end=1
         )
     else:
         check_for_cli_updates()
@@ -52,18 +52,17 @@ def main():
 
         if tracer.has_traced():
             log.extra(
-                "[cyan dim]To run again do:[/cyan dim]",
+                f"[cyan dim]{_('msg.main.tracer.run_again')}[/cyan dim]",
                 f"[cyan]     {cli.command} {tracer.command()}[/cyan]",
             )
             command_as_aliases = tracer.command_as_aliases(tools, envs)
             if command_as_aliases:
                 log.extra(
-                    "[cyan dim]  or:[/cyan dim]",
+                    f"[cyan dim]  {_('msg.main.tracer.or')}[/cyan dim]",
                     f"[cyan]     {cli.command} {command_as_aliases}[/cyan]",
                 )
         store_user_data(
-            HexagonStorageKeys.last_command.value,
-            f"{cli.command} {tracer.command()}",
+            HexagonStorageKeys.last_command.value, f"{cli.command} {tracer.command()}"
         )
     except KeyboardInterrupt:
         sys.exit(1)

--- a/hexagon/actions/external/docker_registry.py
+++ b/hexagon/actions/external/docker_registry.py
@@ -7,7 +7,9 @@ from InquirerPy import inquirer
 
 from hexagon.support.args import cli_arg
 from hexagon.support.tracer import tracer
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
+
+_ = translator
 
 
 def main(tool, env, env_args, cli_args):
@@ -25,7 +27,7 @@ def main(tool, env, env_args, cli_args):
     image = tracer.tracing(
         _image
         or inquirer.fuzzy(
-            message="¿Qué imagen estás buscando?",
+            message=_("action.actions.external.docker_registry.prompt_docker_image"),
             choices=lambda _: get_authenticated(
                 f"https://{registry_host}/v2/_catalog", "repositories"
             ),
@@ -35,7 +37,7 @@ def main(tool, env, env_args, cli_args):
     tag = tracer.tracing(
         _filter
         or inquirer.fuzzy(
-            message="¿Qué tag?",
+            message=_("action.actions.external.docker_registry.prompt_tag"),
             choices=lambda _: get_authenticated(
                 f"https://{registry_host}/v2/{image}/tags/list", "tags"
             ),
@@ -43,10 +45,13 @@ def main(tool, env, env_args, cli_args):
     )
 
     clipboard.copy(f"{registry_host}/{image}:{tag}")
-    log.result(f"[dim][u]{registry_host}/{image}:{tag}[/u] se copió al portapapeles")
+    log.result(
+        f"[dim][u]{registry_host}/{image}:{tag}[/u] {_('msg.actions.external.docker_registry.copied_to_clipboard')}"
+    )
 
     manifest = inquirer.confirm(
-        message="¿Te gustaría ver el manifest?", default=False
+        message=_("action.actions.external.docker_registry.confirm_see_manifest"),
+        default=False,
     ).execute()
 
     if manifest:

--- a/hexagon/actions/external/open_link.py
+++ b/hexagon/actions/external/open_link.py
@@ -1,9 +1,11 @@
 import webbrowser
 
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
+
+_ = translator
 
 
 def main(tool, env, env_args, cli_args):
     url = env_args
-    log.result("Opening url: " + url)
+    log.result(_("msg.actions.external.open_link.result").format(url=url))
     webbrowser.open(url)

--- a/hexagon/actions/external/seed/__init__.py
+++ b/hexagon/actions/external/seed/__init__.py
@@ -23,10 +23,7 @@ def main(tool, env, env_args, cli_args):
 
     seed = tracer.tracing(
         seed
-        or inquirer.fuzzy(
-            message="¿Qué seed querés usar?",
-            choices=SEEDS,
-        ).execute()
+        or inquirer.fuzzy(message="¿Qué seed querés usar?", choices=SEEDS).execute()
     )
 
     if seed == "springboot":

--- a/hexagon/actions/internal/create_new_tool.py
+++ b/hexagon/actions/internal/create_new_tool.py
@@ -7,15 +7,17 @@ from InquirerPy.validator import PathValidator
 from hexagon.domain.tool import ActionTool, ToolType
 from hexagon.domain import configuration
 from hexagon.actions import external
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
+
+_ = translator
 
 
-def main(*_):
+def main():
     create_action = False
     new_tool = ActionTool(
         name="invalid",
         action=inquirer.fuzzy(
-            message="Choose the action of your tool:",
+            message=_("action.actions.internal.create_new_tool.choose_action"),
             validate=lambda x: x,
             choices=external.__all__ + ["new_action"],
         ).execute(),
@@ -24,12 +26,12 @@ def main(*_):
     if new_tool.action == "new_action":
         create_action = True
         new_tool.action = inquirer.text(
-            message="What name would you like to give your new action?",
+            message=_("action.actions.internal.create_new_tool.input_action"),
             validate=lambda x: x,
         ).execute()
 
     new_tool.type = inquirer.select(
-        message="What type of tool is it?",
+        message=_("action.actions.internal.create_new_tool.choose_type"),
         choices=[
             {"value": ToolType.web, "name": ToolType.web.value},
             {"value": ToolType.shell, "name": ToolType.shell.value},
@@ -38,42 +40,50 @@ def main(*_):
     ).execute()
 
     new_tool.name = inquirer.text(
-        message="What command would you like to give your tool?",
+        message=_("action.actions.internal.create_new_tool.input_name"),
         validate=lambda x: x,
         default=new_tool.action.replace("_", "-"),
     ).execute()
 
     new_tool.alias = inquirer.text(
-        message="Would you like to add an alias/shortcut? (empty for none)",
+        message=_("action.actions.internal.create_new_tool.input_alias"),
         default="".join([z[:1] for z in new_tool.name.split("-")]),
         filter=lambda r: r or None,
     ).execute()
 
     new_tool.long_name = inquirer.text(
-        message="Would you like to add a long name? (this will be displayed instead of command)",
+        message=_("action.actions.internal.create_new_tool.input_long_name"),
         filter=lambda r: r or None,
     ).execute()
 
     new_tool.description = inquirer.text(
-        message="Would you like to add a description? (this will be displayed along side command/long_name)",
+        message=_("action.actions.internal.create_new_tool.input_description"),
         filter=lambda r: r or None,
     ).execute()
 
-    cli, tools, _ = configuration.refresh()
+    cli, tools, envs = configuration.refresh()
 
     if create_action:
         if not configuration.custom_tools_path:
-            log.info("[magenta]Your CLI does not have a custom tools dir.")
+            log.info(
+                f'[magenta]{_("msg.actions.internal.create_new_tool.custom_tools_dir_not_set")}'
+            )
             configuration.update_custom_tools_path(
                 inquirer.filepath(
-                    message="Where would you like it to be? "
-                    "(can be absolute path or relative to YAML. ie: ./tools or .)",
+                    message=_(
+                        "action.actions.internal.create_new_tool.input_custom_tools_path"
+                    ),
                     default=".",
                     validate=PathValidator(
-                        is_dir=True, message="Please select a valid directory"
+                        is_dir=True,
+                        message=_(
+                            "error.actions.internal.create_new_tool.insert_valid_directory"
+                        ),
                     ),
                 ).execute(),
-                comment="relative to this file",
+                comment=_(
+                    "msg.actions.internal.create_new_tool.input_custom_tools_path_comment"
+                ),
             )
 
         copytree(

--- a/hexagon/actions/internal/create_new_tool.py
+++ b/hexagon/actions/internal/create_new_tool.py
@@ -12,7 +12,7 @@ from hexagon.support.printer import log, translator
 _ = translator
 
 
-def main():
+def main(*__):
     create_action = False
     new_tool = ActionTool(
         name="invalid",
@@ -66,7 +66,9 @@ def main():
     if create_action:
         if not configuration.custom_tools_path:
             log.info(
-                f'[magenta]{_("msg.actions.internal.create_new_tool.custom_tools_dir_not_set")}'
+                "[magenta]{}".format(
+                    _("msg.actions.internal.create_new_tool.custom_tools_dir_not_set")
+                )
             )
             configuration.update_custom_tools_path(
                 inquirer.filepath(

--- a/hexagon/actions/internal/install_cli.py
+++ b/hexagon/actions/internal/install_cli.py
@@ -57,7 +57,9 @@ def main(*__):
         )
     _make_executable(command_path)
     log.info(
-        f"[green]{_('icon.global.ok')} [white][u]{_('msg.actions.internal.install_cli.success')}",
+        "[green]{0} [white][u]{1}".format(
+            _("icon.global.ok"), _("msg.actions.internal.install_cli.success")
+        ),
         gap_end=1,
         gap_start=1,
     )

--- a/hexagon/actions/internal/install_cli.py
+++ b/hexagon/actions/internal/install_cli.py
@@ -6,8 +6,10 @@ from InquirerPy.validator import PathValidator
 from prompt_toolkit.validation import ValidationError
 
 from hexagon.domain import configuration
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
 from hexagon.support.storage import load_user_data, HexagonStorageKeys, store_user_data
+
+_ = translator
 
 
 class YamlFileValidator(PathValidator):
@@ -16,17 +18,17 @@ class YamlFileValidator(PathValidator):
         extension = document.text.split("/")[-1].split(".")[-1]
         if extension != "yaml" and extension != "yml":
             raise ValidationError(
-                message=self.message,
-                cursor_position=document.cursor_position,
+                message=self.message, cursor_position=document.cursor_position,
             )
 
 
-def main(*_):
+def main(*__):
     src_path = inquirer.filepath(
-        message="Where is your project's hexagon config file?",
+        message=_("action.actions.internal.install_cli.config_file_location"),
         default=str(Path.cwd()),
         validate=YamlFileValidator(
-            is_file=True, message="Please select a valid YAML file"
+            is_file=True,
+            message=_("error.actions.internal.install_cli.select_valid_file"),
         ),
     ).execute()
 
@@ -35,10 +37,11 @@ def main(*_):
     bin_path = (
         load_user_data(HexagonStorageKeys.cli_install_path.value)
         or inquirer.filepath(
-            message="Where do you want your CLI commands to be saved? This should be on your path",
+            message=_("action.actions.internal.install_cli.commands_path"),
             default=str(os.path.expanduser(os.path.join("~", "bin"))),
             validate=PathValidator(
-                is_dir=True, message="Please select a valid directory"
+                is_dir=True,
+                message=_("error.actions.internal.install_cli.select_valid_directory"),
             ),
         ).execute()
     )
@@ -54,7 +57,7 @@ def main(*_):
         )
     _make_executable(command_path)
     log.info(
-        "[green]🗸️ [white][u]All done! Now you can execute your project's CLI like:",
+        f"[green]{_('icon.global.ok')} [white][u]{_('msg.actions.internal.install_cli.success')}",
         gap_end=1,
         gap_start=1,
     )

--- a/hexagon/actions/internal/install_cli.py
+++ b/hexagon/actions/internal/install_cli.py
@@ -18,7 +18,7 @@ class YamlFileValidator(PathValidator):
         extension = document.text.split("/")[-1].split(".")[-1]
         if extension != "yaml" and extension != "yml":
             raise ValidationError(
-                message=self.message, cursor_position=document.cursor_position,
+                message=self.message, cursor_position=document.cursor_position
             )
 
 

--- a/hexagon/actions/internal/save_new_alias.py
+++ b/hexagon/actions/internal/save_new_alias.py
@@ -73,5 +73,5 @@ def save_new_alias(alias_name, command):
 
 def __pretty_print_created_alias(aliases_file, file, lines_to_show=-10):
     log.gap()
-    log.info(_("msg.actions.internal.save_new_alias.added_to_file".format(file=file)))
+    log.info(_("msg.actions.internal.save_new_alias.added_to_file").format(file=file))
     log.example("\n".join(aliases_file.read().splitlines()[lines_to_show:]))

--- a/hexagon/actions/internal/save_new_alias.py
+++ b/hexagon/actions/internal/save_new_alias.py
@@ -15,7 +15,6 @@ _ = translator
 def main(*__):
     last_command = load_user_data(HexagonStorageKeys.last_command.value)
 
-    # Last command: {last_command}
     log.info(
         _("msg.actions.internal.save_new_alias.last_command").format(
             last_command=last_command
@@ -58,16 +57,23 @@ def save_new_alias(alias_name, command):
         aliases_file.close()
 
     log.info(
-        f"[green]{_('icon.global.ok')}️ [white][u]{_('msg.actions.internal.save_new_alias.success')}",
+        "[green]{} [white][u]{}".format(
+            _("icon.global.ok"), _("msg.actions.internal.save_new_alias.success")
+        ),
         gap_end=1,
     )
     log.result(f"[b]$ {alias_name}")
     log.info(
-        f"[dim][u]{_('msg.actions.internal.save_new_alias.execute_tip')}", gap_start=1
+        "[dim][u]{}".format(_("msg.actions.internal.save_new_alias.execute_tip")),
+        gap_start=1,
     )
-    log.info(f"[dim]{_('msg.actions.internal.save_new_alias.reload_builtins')}")
+    log.info("[dim]{}".format(_("msg.actions.internal.save_new_alias.reload_builtins")))
     log.info(
-        f"[dim]{_('msg.actions.internal.save_new_alias.run_source').format(file_path=aliases_file_path)}"
+        "[dim]{}".format(
+            _("msg.actions.internal.save_new_alias.run_source").format(
+                file_path=aliases_file_path
+            )
+        )
     )
 
 

--- a/hexagon/actions/internal/save_new_alias.py
+++ b/hexagon/actions/internal/save_new_alias.py
@@ -3,19 +3,30 @@ import os
 from InquirerPy import inquirer
 from InquirerPy.validator import EmptyInputValidator
 
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
 from hexagon.support.storage import (
     HexagonStorageKeys,
     load_user_data,
 )
 
+_ = translator
 
-def main(*_):
+
+def main(*__):
     last_command = load_user_data(HexagonStorageKeys.last_command.value)
 
+    # Last command: {last_command}
+    log.info(
+        _("msg.actions.internal.save_new_alias.last_command").format(
+            last_command=last_command
+        )
+    )
+
     alias_name = inquirer.text(
-        message=f"Last command: {last_command} Alias name?",
-        validate=EmptyInputValidator("Please insert a valid unix alias."),
+        message=_("action.actions.internal.save_new_alias.prompt_alias_name"),
+        validate=EmptyInputValidator(
+            _("error.actions.internal.save_new_alias.insert_valid_alias")
+        ),
     ).execute()
 
     save_new_alias(alias_name, last_command)
@@ -47,17 +58,20 @@ def save_new_alias(alias_name, command):
         aliases_file.close()
 
     log.info(
-        "[green]🗸️ [white][u]All done! You can now run your alias like:", gap_end=1
+        f"[green]{_('icon.global.ok')}️ [white][u]{_('msg.actions.internal.save_new_alias.success')}",
+        gap_end=1,
     )
     log.result(f"[b]$ {alias_name}")
-    log.info("[dim][u]Tip:", gap_start=1)
-    log.info("[dim]You probably need to reload your shell built-ins.")
     log.info(
-        f"[dim]Either by running 'source {aliases_file_path}' or restarting your terminal."
+        f"[dim][u]{_('msg.actions.internal.save_new_alias.execute_tip')}", gap_start=1
+    )
+    log.info(f"[dim]{_('msg.actions.internal.save_new_alias.reload_builtins')}")
+    log.info(
+        f"[dim]{_('msg.actions.internal.save_new_alias.run_source').format(file_path=aliases_file_path)}"
     )
 
 
 def __pretty_print_created_alias(aliases_file, file, lines_to_show=-10):
     log.gap()
-    log.info(f"Added alias to {file}")
+    log.info(_("msg.actions.internal.save_new_alias.added_to_file".format(file=file)))
     log.example("\n".join(aliases_file.read().splitlines()[lines_to_show:]))

--- a/hexagon/domain/configuration.py
+++ b/hexagon/domain/configuration.py
@@ -8,7 +8,10 @@ from ruamel.yaml import YAML
 from hexagon.domain.cli import Cli
 from hexagon.domain.env import Env
 from hexagon.domain.tool import ActionTool, GroupTool, Tool, ToolType
+from hexagon.support.printer import translator
 from hexagon.support.yaml import display_yaml_errors
+
+_ = translator
 
 
 class ConfigFile(BaseModel):
@@ -21,13 +24,13 @@ class Configuration:
     __defaults = [
         ActionTool(
             name="save-alias",
-            long_name="Save Last Command as Linux Alias",
+            long_name=_("msg.domain.configuration.save_alias_long_name"),
             type=ToolType.hexagon,
             action="hexagon.actions.internal.save_new_alias",
         ),
         ActionTool(
             name="create-tool",
-            long_name="Create A New Tool",
+            long_name=_("msg.domain.configuration.create_tool_long_name"),
             type=ToolType.hexagon,
             action="hexagon.actions.internal.create_new_tool",
         ),
@@ -99,8 +102,8 @@ class Configuration:
             [
                 ActionTool(
                     name="install",
-                    long_name="Install CLI",
-                    description="Install a custom project CLI from a YAML file.",
+                    long_name=_("msg.domain.configuration.install_cli_long_name"),
+                    description=_("msg.domain.configuration.save_alias_description"),
                     type=ToolType.hexagon,
                     action="hexagon.actions.internal.install_cli",
                 )

--- a/hexagon/domain/configuration.py
+++ b/hexagon/domain/configuration.py
@@ -103,7 +103,7 @@ class Configuration:
                 ActionTool(
                     name="install",
                     long_name=_("msg.domain.configuration.install_cli_long_name"),
-                    description=_("msg.domain.configuration.save_alias_description"),
+                    description=_("msg.domain.configuration.install_cli_description"),
                     type=ToolType.hexagon,
                     action="hexagon.actions.internal.install_cli",
                 )

--- a/hexagon/domain/options.py
+++ b/hexagon/domain/options.py
@@ -39,12 +39,7 @@ class Options(BaseSettings):
         env_prefix = "HEXAGON_"
 
         @classmethod
-        def customise_sources(
-            cls,
-            init_settings,
-            env_settings,
-            file_secret_settings,
-        ):
+        def customise_sources(cls, init_settings, env_settings, file_secret_settings):
             # TODO: allow CLIs to override options from app.yaml (ie: cli.options.update_time_between_checks)
             return (
                 env_settings,

--- a/hexagon/plugins/analytics.py
+++ b/hexagon/plugins/analytics.py
@@ -33,17 +33,13 @@ def main():
 
     HexagonHooks.tool_selected.subscribe(
         HookSubscription(
-            SUBSCRIPTION_NAME,
-            _track_selection,
-            type=HookSubscrptionType.background,
+            SUBSCRIPTION_NAME, _track_selection, type=HookSubscrptionType.background
         )
     )
 
     HexagonHooks.env_selected.subscribe(
         HookSubscription(
-            SUBSCRIPTION_NAME,
-            _track_selection,
-            type=HookSubscrptionType.background,
+            SUBSCRIPTION_NAME, _track_selection, type=HookSubscrptionType.background
         )
     )
 
@@ -51,9 +47,7 @@ def main():
         HookSubscription(
             SUBSCRIPTION_NAME,
             lambda data: analytics.system_event(
-                SystemEvent.execution,
-                tool=data.tool.name,
-                duration=data.duration,
+                SystemEvent.execution, tool=data.tool.name, duration=data.duration
             ),
             type=HookSubscrptionType.background,
         )

--- a/hexagon/support/analytics/__init__.py
+++ b/hexagon/support/analytics/__init__.py
@@ -5,10 +5,11 @@ from InquirerPy import inquirer
 
 from hexagon.domain import get_options
 from hexagon.domain.options import update_options
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
 from hexagon.support.storage import store_local_data, get_local_data_dir
 from hexagon.support.analytics import google_analytics
 
+_ = translator
 _data_file_name = "events_" + datetime.date.today().isoformat()
 
 
@@ -74,13 +75,15 @@ def _send_event(s):
 def _send_telemetry():
     opt = get_options()
     if opt.send_telemetry is None:
+        log.info(_("msg.support.analytics.telemetry_notice"))
         log.info(
-            "In order to make Hexagon better we record anonymous usage statistics. "
-            f"You can see what's collected in {get_local_data_dir()}",
+            _("msg.support.analytics.telemetry_directory").format(
+                directory=get_local_data_dir()
+            ),
             gap_start=1,
         )
         opt.send_telemetry = inquirer.confirm(
-            message="Do you agree to participate?", default=True
+            message=_("action.support.analytics.confirm_telemetry"), default=True
         ).execute()
         update_options(opt)
     return opt.send_telemetry

--- a/hexagon/support/cli/git.py
+++ b/hexagon/support/cli/git.py
@@ -1,6 +1,11 @@
+from typing import Optional
+
 from hexagon.support.cli.command import output_from_command_in_cli_project_path
+from hexagon.support.printer import translator
 from hexagon.support.storage import load_user_data, store_user_data
 import re
+
+_ = translator
 
 
 class CliGitConfig:
@@ -13,10 +18,9 @@ class CliGitConfig:
 
 
 CLI_GIT_CONFIG_STORAGE_KEY = "git-config"
-GENERAL_GIT_CONFIG_ERROR = "Please make sure your hexagon configuration file is located in a working git repository"
 
 
-def load_cli_git_config() -> CliGitConfig:
+def load_cli_git_config() -> Optional[CliGitConfig]:
     raw_data = load_user_data(CLI_GIT_CONFIG_STORAGE_KEY)
     try:
         write_dict = {}
@@ -28,9 +32,7 @@ def load_cli_git_config() -> CliGitConfig:
             elif "origin" in remotes:
                 remote = "origin"
             else:
-                raise Exception(
-                    "Couldn't get the remote name from your cli's repository, too many choices and origin is not present"
-                )
+                raise Exception(_("error.support.cli.git.failed_to_get_remote"))
 
             write_dict["remote"] = remote
 

--- a/hexagon/support/execute/action.py
+++ b/hexagon/support/execute/action.py
@@ -50,7 +50,7 @@ def _execute_action(tool: ActionTool, env_args, env: Env, args, custom_tools_pat
 
         split_action = action_to_execute.split(" ")
         return_code, executed_command = _execute_command(
-            split_action[0], env_args, args, action_args=split_action[1:],
+            split_action[0], env_args, args, action_args=split_action[1:]
         )
 
         if return_code != 0:
@@ -165,7 +165,7 @@ def __pretty_print_external_error(action_id, custom_tools_path):
 
     if trace:
         log.example(
-            rich_traceback.Traceback.from_exception(exc_type, exc_value, trace,),
+            rich_traceback.Traceback.from_exception(exc_type, exc_value, trace),
             decorator_start=False,
             decorator_end=False,
         )

--- a/hexagon/support/execute/action.py
+++ b/hexagon/support/execute/action.py
@@ -63,20 +63,31 @@ def _execute_action(tool: ActionTool, env_args, env: Env, args, custom_tools_pat
 
             if return_code == 127:
                 log.error(
-                    f"{_('error.support.execute.action.could_not_execute')} [bold]{tool.action}"
+                    "{} [bold]{}".format(
+                        _("error.support.execute.action.could_not_execute"), tool.action
+                    )
                 )
                 log.error(_("error.support.execute.action.we_tried"))
                 log.error(
-                    f"  - {_('error.support.execute.action.attempt_cli_custom_dir')} [bold]{custom_tools_path}"
+                    "  - {} [bold]{}".format(
+                        _("error.support.execute.action.attempt_cli_custom_dir"),
+                        custom_tools_path,
+                    )
                 )
                 log.error(
-                    f"  - {_('error.support.execute.action.attempt_internal_tools')}"
+                    "  - {} (hexagon.actions.external)".format(
+                        _("error.support.execute.action.attempt_internal_tools")
+                    )
                 )
                 log.error(
-                    f"  - {_('error.support.execute.action.attempt_known_script')}"
+                    "  - {} (.js, .sh)".format(
+                        _("error.support.execute.action.attempt_known_script")
+                    )
                 )
                 log.error(
-                    f"  - {_('error.support.execute.action.attempt_inline_command')}"
+                    "  - {}".format(
+                        _("error.support.execute.action.attempt_inline_command")
+                    )
                 )
             sys.exit(1)
 
@@ -97,7 +108,11 @@ def _execute_python_module(
         return True
     except Exception:
         __pretty_print_external_error(action_id, custom_tools_path)
-        log.error("error.support.execute.action.execute_tool_failed")
+        log.error(
+            _("error.support.execute.action.execute_tool_failed").format(
+                action=action_id
+            )
+        )
         sys.exit(1)
 
 

--- a/hexagon/support/execute/action.py
+++ b/hexagon/support/execute/action.py
@@ -13,9 +13,10 @@ from hexagon.domain.tool import ActionTool
 from hexagon.domain.tool.execution import ToolExecutionData
 from hexagon.domain.env import Env
 from hexagon.domain import configuration
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
 from hexagon.support.hooks import HexagonHooks
 
+_ = translator
 _command_by_file_extension = {"js": "node", "sh": "sh"}
 
 
@@ -49,24 +50,34 @@ def _execute_action(tool: ActionTool, env_args, env: Env, args, custom_tools_pat
 
         split_action = action_to_execute.split(" ")
         return_code, executed_command = _execute_command(
-            split_action[0],
-            env_args,
-            args,
-            action_args=split_action[1:],
+            split_action[0], env_args, args, action_args=split_action[1:],
         )
 
         if return_code != 0:
-            log.error(f"{executed_command} returned code: {return_code}\n")
+            # "{executed_command} returned code: {return_code}\n"
+            log.error(
+                _("error.support.execute.action.command_result_code").format(
+                    executed_command=executed_command, return_code=return_code
+                )
+            )
 
             if return_code == 127:
-                log.error(f"Hexagon couldn't execute the action: [bold]{tool.action}")
-                log.error("We tried:")
-                log.error(f"  - Your CLI's custom_tools_dir: [bold]{custom_tools_path}")
                 log.error(
-                    "  - Hexagon repository of external actions (hexagon.actions.external)"
+                    f"{_('error.support.execute.action.could_not_execute')} [bold]{tool.action}"
                 )
-                log.error("  - A known script file (.js, .sh)")
-                log.error("  - Running your action as a shell command directly")
+                log.error(_("error.support.execute.action.we_tried"))
+                log.error(
+                    f"  - {_('error.support.execute.action.attempt_cli_custom_dir')} [bold]{custom_tools_path}"
+                )
+                log.error(
+                    f"  - {_('error.support.execute.action.attempt_internal_tools')}"
+                )
+                log.error(
+                    f"  - {_('error.support.execute.action.attempt_known_script')}"
+                )
+                log.error(
+                    f"  - {_('error.support.execute.action.attempt_inline_command')}"
+                )
             sys.exit(1)
 
 
@@ -86,7 +97,7 @@ def _execute_python_module(
         return True
     except Exception:
         __pretty_print_external_error(action_id, custom_tools_path)
-        log.error(f"Execution of tool [bold]{action_id}[/bold] failed")
+        log.error("error.support.execute.action.execute_tool_failed")
         sys.exit(1)
 
 
@@ -136,7 +147,7 @@ def _load_action_module(action_id: str, custom_tools_path):
             return None
         else:
             __pretty_print_external_error(action_id, custom_tools_path)
-            log.error("Your custom action seems to have a module dependency error")
+            log.error(_("error.support.execute.action.python_dependency_error"))
             sys.exit(1)
 
 
@@ -154,11 +165,7 @@ def __pretty_print_external_error(action_id, custom_tools_path):
 
     if trace:
         log.example(
-            rich_traceback.Traceback.from_exception(
-                exc_type,
-                exc_value,
-                trace,
-            ),
+            rich_traceback.Traceback.from_exception(exc_type, exc_value, trace,),
             decorator_start=False,
             decorator_end=False,
         )

--- a/hexagon/support/execute/tool.py
+++ b/hexagon/support/execute/tool.py
@@ -18,9 +18,11 @@ from hexagon.domain.configuration import (
     read_configuration_file,
     register_custom_tools_path,
 )
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
 import sys
 import os
+
+_ = translator
 
 
 def select_and_execute_tool(
@@ -74,10 +76,10 @@ def select_and_execute_tool(
 
 GO_BACK_TOOL = Tool(
     name="goback",
-    long_name="Go back",
+    long_name=_("msg.support.execute.tool.go_back_long_name"),
     type=ToolType.function,
-    description="Go back to the previous menu",
-    icon="🠔",
+    description=_("msg.support.execute.tool.go_back_description"),
+    icon=_("icon.global.go_back"),
     traced=False,
 )
 
@@ -94,7 +96,12 @@ def _execute_group_tool(
     try:
         group_config_yaml = read_configuration_file(config_file_path)
     except FileNotFoundError:
-        log.error(f"File {config_file_path} could not be found")
+        # "File {config_file_path} could not be found"
+        log.error(
+            _("error.support.execute.tool.group_tool_file_not_found").format(
+                config_file_path=config_file_path
+            )
+        )
         sys.exit(1)
 
     try:

--- a/hexagon/support/help.py
+++ b/hexagon/support/help.py
@@ -4,7 +4,9 @@ from typing import List
 from hexagon.domain.env import Env
 from hexagon.domain.tool import Tool
 from hexagon.domain.cli import Cli
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
+
+_ = translator
 
 
 def print_help(cli_config: Cli, tools: List[Tool], envs: List[Env]):
@@ -18,13 +20,13 @@ def print_help(cli_config: Cli, tools: List[Tool], envs: List[Env]):
     """
     if cli_config.name == "Hexagon":
         log.info("[bold]Hexagon", gap_end=1)
-        log.info("You are executing Hexagon without an install.")
-        log.info('To get started run hexagon\'s "Install Hexagon" tool')
+        log.info(_("msg.support.help.no_install"))
+        log.info(_("msg.support.help.get_started"))
         return
 
     log.info(f"[bold]{cli_config.name}", gap_end=1)
 
-    log.info("[bold][u]Envs:")
+    log.info(f"[bold][u]{_('msg.global.envs')}:")
     for env in envs:
         log.info(
             f'  {env.name + (" (" + env.alias + ")" if env.alias else ""):<60}[dim]{env.long_name or ""}'
@@ -34,7 +36,7 @@ def print_help(cli_config: Cli, tools: List[Tool], envs: List[Env]):
             # the same for tools
             log.info(f'  {"": <60}[dim]{env.description}', gap_end=1)
 
-    log.info("[bold][u]Tools:", gap_start=2)
+    log.info(f"[bold][u]{_('msg.global.tools')}:", gap_start=2)
 
     data = sorted(tools, key=lambda t: t.type, reverse=True)
 

--- a/hexagon/support/help.py
+++ b/hexagon/support/help.py
@@ -26,7 +26,7 @@ def print_help(cli_config: Cli, tools: List[Tool], envs: List[Env]):
 
     log.info(f"[bold]{cli_config.name}", gap_end=1)
 
-    log.info(f"[bold][u]{_('msg.global.envs')}:")
+    log.info("[bold][u]{}:".format(_("msg.global.envs")))
     for env in envs:
         log.info(
             f'  {env.name + (" (" + env.alias + ")" if env.alias else ""):<60}[dim]{env.long_name or ""}'
@@ -36,7 +36,7 @@ def print_help(cli_config: Cli, tools: List[Tool], envs: List[Env]):
             # the same for tools
             log.info(f'  {"": <60}[dim]{env.description}', gap_end=1)
 
-    log.info(f"[bold][u]{_('msg.global.tools')}:", gap_start=2)
+    log.info("[bold][u]{}:".format(_("msg.global.tools")), gap_start=2)
 
     data = sorted(tools, key=lambda t: t.type, reverse=True)
 

--- a/hexagon/support/hooks/hook.py
+++ b/hexagon/support/hooks/hook.py
@@ -2,6 +2,10 @@ from enum import Enum
 from typing import Callable, Generic, List, TypeVar
 import threading
 
+from hexagon.support.printer import translator
+
+_ = translator
+
 
 class HookSubscrptionType(Enum):
     blocking = "blocking"
@@ -47,4 +51,9 @@ class Hook(Generic[T]):
                 )
                 thread.start()
             else:
-                raise Exception(f"Unknown HookSubscriptionType {subscription.type}")
+                # Unknown HookSubscriptionType {subscription_type}
+                raise Exception(
+                    _("error.support.hooks.hook.unknown_type").format(
+                        subscription_type=subscription.type
+                    )
+                )

--- a/hexagon/support/printer/__init__.py
+++ b/hexagon/support/printer/__init__.py
@@ -14,6 +14,6 @@ theme = load_theme()
 
 log = Logger(Console(color_system="auto" if theme.show_colors else None), theme)
 
-gettext.bindtextdomain("hexagon", LOCALEDIR)
-gettext.textdomain("hexagon")
-translator: Callable[[str], str] = gettext.gettext
+el = gettext.translation("hexagon", localedir=LOCALEDIR, languages=["en", "es"])
+el.install()
+translator: Callable[[str], str] = el.gettext

--- a/hexagon/support/printer/__init__.py
+++ b/hexagon/support/printer/__init__.py
@@ -14,6 +14,8 @@ theme = load_theme()
 
 log = Logger(Console(color_system="auto" if theme.show_colors else None), theme)
 
-el = gettext.translation("hexagon", localedir=LOCALEDIR, languages=["en", "es"])
+el = gettext.translation(
+    "hexagon", localedir=LOCALEDIR, languages=["en", "es"], fallback=True
+)
 el.install()
 translator: Callable[[str], str] = el.gettext

--- a/hexagon/support/printer/__init__.py
+++ b/hexagon/support/printer/__init__.py
@@ -14,8 +14,12 @@ theme = load_theme()
 
 log = Logger(Console(color_system="auto" if theme.show_colors else None), theme)
 
-el = gettext.translation(
-    "hexagon", localedir=LOCALEDIR, languages=["en", "es"], fallback=True
-)
+try:
+    el = gettext.translation("hexagon", localedir=LOCALEDIR)
+except FileNotFoundError:
+    el = gettext.translation(
+        "hexagon", localedir=LOCALEDIR, languages=["en"], fallback=True
+    )
 el.install()
+
 translator: Callable[[str], str] = el.gettext

--- a/hexagon/support/printer/__init__.py
+++ b/hexagon/support/printer/__init__.py
@@ -1,11 +1,16 @@
+from typing import Callable
+
 from rich.console import Console
 
 from hexagon.support.printer.logger import Logger
 from hexagon.support.printer.themes import load_theme
 
+import gettext
+
 theme = load_theme()
 
-log = Logger(
-    Console(color_system="auto" if theme.show_colors else None),
-    theme,
-)
+log = Logger(Console(color_system="auto" if theme.show_colors else None), theme)
+
+gettext.bindtextdomain("hexagon", "locales")
+gettext.textdomain("hexagon")
+translator: Callable[[str], str] = gettext.gettext

--- a/hexagon/support/printer/__init__.py
+++ b/hexagon/support/printer/__init__.py
@@ -1,3 +1,4 @@
+import os
 from typing import Callable
 
 from rich.console import Console
@@ -7,10 +8,12 @@ from hexagon.support.printer.themes import load_theme
 
 import gettext
 
+LOCALEDIR = os.environ.get("HEXAGON_LOCALES_DIR", "locales")
+
 theme = load_theme()
 
 log = Logger(Console(color_system="auto" if theme.show_colors else None), theme)
 
-gettext.bindtextdomain("hexagon", "locales")
+gettext.bindtextdomain("hexagon", LOCALEDIR)
 gettext.textdomain("hexagon")
 translator: Callable[[str], str] = gettext.gettext

--- a/hexagon/support/storage.py
+++ b/hexagon/support/storage.py
@@ -1,4 +1,3 @@
-from hexagon.support.printer import translator
 from hexagon.utils.dict import merge_dictionaries_deep
 import os
 from pathlib import Path
@@ -9,8 +8,6 @@ from enum import Enum
 from shutil import rmtree
 
 HEXAGON_STORAGE_APP = "hexagon"
-
-_ = translator
 
 
 class HexagonStorageKeys(Enum):
@@ -36,7 +33,6 @@ _extension_by_value_type = {
     StorageValueType.text_multiline: ".txt",
     StorageValueType.dictionary: ".yaml",
 }
-
 
 _config_storage_path = None
 _data_storage_path = None
@@ -82,8 +78,7 @@ def _storage_value_type_by_data_type(data: InputDataType):
         return StorageValueType.dictionary
     else:
         raise Exception(
-            # Type {type} cannot be stored: supported types are str, List[str] or Dict
-            _("error.support.storage.unsupported_type").format(type=type(data).__name__)
+            f"Type {type} cannot be stored: supported types are str, List[str] or Dict"
         )
 
 

--- a/hexagon/support/storage.py
+++ b/hexagon/support/storage.py
@@ -1,3 +1,4 @@
+from hexagon.support.printer import translator
 from hexagon.utils.dict import merge_dictionaries_deep
 import os
 from pathlib import Path
@@ -8,6 +9,8 @@ from enum import Enum
 from shutil import rmtree
 
 HEXAGON_STORAGE_APP = "hexagon"
+
+_ = translator
 
 
 class HexagonStorageKeys(Enum):
@@ -79,7 +82,8 @@ def _storage_value_type_by_data_type(data: InputDataType):
         return StorageValueType.dictionary
     else:
         raise Exception(
-            f"Type {type(data).__name__} cannot be stored: supported types are str, List[str] or Dict"
+            # Type {type} cannot be stored: supported types are str, List[str] or Dict
+            _("error.support.storage.unsupported_type").format(type=type(data).__name__)
         )
 
 

--- a/hexagon/support/update/cli.py
+++ b/hexagon/support/update/cli.py
@@ -46,7 +46,7 @@ def check_for_cli_updates():
     if "is behind" in branch_status:
         log.info(
             _("msg.support.update.cli.new_version_available").format(
-                cli_name=cli.name, colors=dict(cli_start="[cyan]", cli_end="[/cyan]")
+                cli_name=cli.name, cli_start="[cyan]", cli_end="[/cyan]"
             )
         )
         if not inquirer.confirm(

--- a/hexagon/support/update/cli.py
+++ b/hexagon/support/update/cli.py
@@ -3,13 +3,15 @@ from hexagon.support.cli.command import (
     execute_command_in_cli_project_path,
     output_from_command_in_cli_project_path,
 )
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
 from hexagon.support.update.shared import already_checked_for_updates
 import os
 import re
 from hexagon.domain import cli
 from InquirerPy import inquirer
 import sys
+
+_ = translator
 
 
 def check_for_cli_updates():
@@ -42,11 +44,18 @@ def check_for_cli_updates():
     branch_status = output_from_command_in_cli_project_path("git status -uno")
 
     if "is behind" in branch_status:
-        log.info(f"New [cyan]{cli.name} [white]version available")
+        # "New [cyan]{cli.name} [white]version available"
+        log.info(
+            _("msg.support.update.cli.new_version_available").format(
+                cli_name=cli.name, colors=dict(cli_start="[cyan]", cli_end="[/cyan]")
+            )
+        )
         if not inquirer.confirm("Would you like to update?", default=True).execute():
             return
         execute_command_in_cli_project_path("git pull", show_stdout=True)
-        log.info("[green]🗸 [white]Updated to latest version")
+        log.info(
+            f"[green]{_('icon.global.ok')}️[white]{_('msg.support.update.cli.updated')}"
+        )
         log.finish()
         sys.exit(1)
 

--- a/hexagon/support/update/cli.py
+++ b/hexagon/support/update/cli.py
@@ -44,17 +44,20 @@ def check_for_cli_updates():
     branch_status = output_from_command_in_cli_project_path("git status -uno")
 
     if "is behind" in branch_status:
-        # "New [cyan]{cli.name} [white]version available"
         log.info(
             _("msg.support.update.cli.new_version_available").format(
                 cli_name=cli.name, colors=dict(cli_start="[cyan]", cli_end="[/cyan]")
             )
         )
-        if not inquirer.confirm("Would you like to update?", default=True).execute():
+        if not inquirer.confirm(
+            _("action.support.update.cli.confirm_update"), default=True
+        ).execute():
             return
         execute_command_in_cli_project_path("git pull", show_stdout=True)
         log.info(
-            f"[green]{_('icon.global.ok')}️[white]{_('msg.support.update.cli.updated')}"
+            "[green]{}️[white]{}".format(
+                _("icon.global.ok"), _("msg.support.update.cli.updated")
+            )
         )
         log.finish()
         sys.exit(1)

--- a/hexagon/support/update/hexagon.py
+++ b/hexagon/support/update/hexagon.py
@@ -171,12 +171,10 @@ def check_for_hexagon_updates():
     log.info(
         _("msg.support.update.hexagon.new_version_available").format(
             latest_version=latest_github_release_version,
-            colors=dict(
-                hexagon_start="[cyan]",
-                hexagon_end="[/cyan]",
-                version_start="[green]",
-                version_end="[/green]",
-            ),
+            hexagon_start="[cyan]",
+            hexagon_end="[/cyan]",
+            version_start="[green]",
+            version_end="[/green]",
         )
     )
 

--- a/hexagon/support/update/hexagon.py
+++ b/hexagon/support/update/hexagon.py
@@ -167,7 +167,7 @@ def check_for_hexagon_updates():
     if current_version >= parse_version(latest_github_release_version):
         return
 
-    # New {colors.hexagon_start}hexagon{colors.hexagon_end} version available {colors.version_start}{latest_version}{colors.version_end}!
+    # FIXME find a better way of handling colors in translations
     log.info(
         _("msg.support.update.hexagon.new_version_available").format(
             latest_version=latest_github_release_version,

--- a/hexagon/support/update/hexagon.py
+++ b/hexagon/support/update/hexagon.py
@@ -12,9 +12,11 @@ from urllib.request import Request, urlopen
 from packaging.version import parse as parse_version, Version
 from markdown import Markdown
 from io import StringIO
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
 from InquirerPy import inquirer
 from functools import reduce
+
+_ = translator
 
 LAST_UPDATE_DATE_FORMAT = "%Y%m%d"
 REPO_ORG = "redbeestudios"
@@ -130,7 +132,7 @@ def _unmark(text):
 def _show_changelog(current_hexagon_version: Version):
     if bool(os.getenv("HEXAGON_UPDATE_SHOW_CHANGELOG", "1")):
 
-        with log.status("Fetching changelog"):
+        with log.status(_("msg.support.update.hexagon.fetching_changelog")):
             changelog = _parse_changelog(current_hexagon_version, REPO_ORG, REPO_NAME)
 
         if changelog:
@@ -141,13 +143,12 @@ def _show_changelog(current_hexagon_version: Version):
 
             entries = reduce(reducer, changelog, [])
             entries.sort(
-                key=lambda entry: CHANGELOG_ENTRY_TYPE_ORDER_MAP[entry.type],
-                reverse=True,
+                key=lambda e: CHANGELOG_ENTRY_TYPE_ORDER_MAP[e.type], reverse=True
             )
             for entry in entries[:CHANGELOG_MAX_ENTRIES]:
                 log.info("  - " + _unmark(entry.message))
             if len(entries) > CHANGELOG_MAX_ENTRIES:
-                log.info("and much more!")
+                log.info(_("msg.support.update.hexagon.and_much_more"))
 
 
 def check_for_hexagon_updates():
@@ -166,29 +167,42 @@ def check_for_hexagon_updates():
     if current_version >= parse_version(latest_github_release_version):
         return
 
+    # New {colors.hexagon_start}hexagon{colors.hexagon_end} version available {colors.version_start}{latest_version}{colors.version_end}!
     log.info(
-        f"New [cyan]hexagon [white]version available [green]{latest_github_release_version}[white]!"
+        _("msg.support.update.hexagon.new_version_available").format(
+            latest_version=latest_github_release_version,
+            colors=dict(
+                hexagon_start="[cyan]",
+                hexagon_end="[/cyan]",
+                version_start="[green]",
+                version_end="[/green]",
+            ),
+        )
     )
 
     _show_changelog(current_version)
 
-    if not inquirer.confirm("Would you like to update?", default=True).execute():
+    if not inquirer.confirm(
+        _("action.support.update.hexagon.confirm_update"), default=True
+    ).execute():
         return
 
-    with log.status("Updating"):
+    with log.status(_("msg.support.update.hexagon.updating")):
         subprocess.check_call(
             f"{sys.executable} -m pip --disable-pip-version-check install https://github.com/{REPO_ORG}/{REPO_NAME}/releases/download/v{latest_github_release_version}/hexagon-{latest_github_release_version}.tar.gz",
             shell=True,
             stdout=subprocess.DEVNULL,
         )
 
-    log.info("[green]🗸️ [white]Updated to latest version")
+    log.info(
+        f"[green]{_('icon.global.ok')}️[white]{_('msg.support.update.hexagon.updated')}"
+    )
     log.finish()
     sys.exit(1)
 
 
 def _latest_github_release():
-    with log.status("Checking for new hexagon versions"):
+    with log.status(_("msg.support.update.hexagon.checking_new_versions")):
         latest_release_request = Request(
             f"https://api.github.com/repos/{REPO_ORG}/{REPO_NAME}/releases/latest"
         )

--- a/hexagon/support/update/hexagon.py
+++ b/hexagon/support/update/hexagon.py
@@ -195,7 +195,9 @@ def check_for_hexagon_updates():
         )
 
     log.info(
-        f"[green]{_('icon.global.ok')}️[white]{_('msg.support.update.hexagon.updated')}"
+        "[green]{}️[white]{}".format(
+            _("icon.global.ok"), _("msg.support.update.hexagon.updated")
+        )
     )
     log.finish()
     sys.exit(1)

--- a/hexagon/support/wax.py
+++ b/hexagon/support/wax.py
@@ -6,6 +6,9 @@ from hexagon.domain.env import Env
 from hexagon.domain.tool import Tool
 from hexagon.domain.wax import Selection, SelectionType
 from hexagon.support.hooks import HexagonHooks
+from hexagon.support.printer import translator
+
+_ = translator
 
 
 def __classifier(value: Union[Tool, Env]):
@@ -55,12 +58,12 @@ def select_env(available_envs: List[Env], tool_envs: dict = None, selected: str 
         if selected
         else (
             inquirer.fuzzy(
-                message="On which environment?",
+                message=_("action.support.wax.select_environment"),
                 choices=__choices_with_long_name(
                     [e for e in available_envs if e.name in tool_envs.keys()]
                 ),
                 validate=lambda x: x and "__separator" not in x,
-                invalid_message="Please select a valid environment",
+                invalid_message=_("error.support.wax.invalid_environment"),
             ).execute(),
             True,
         )
@@ -77,10 +80,10 @@ def select_tool(tools: List[Tool], selected: str = None):
         return _select_and_register_event(selected, tools, target="tool")
 
     name = inquirer.fuzzy(
-        message="Hi, which tool would you like to use today?",
+        message=_("action.support.wax.select_tool"),
         choices=__choices_with_long_name(tools, classifier=__classifier),
         validate=lambda x: x and "__separator" not in x,
-        invalid_message="Please select a valid tool",
+        invalid_message=_("error.support.wax.invalid_tool"),
     ).execute()
 
     return _select_and_register_event(name, tools, target="tool", prompt=True)

--- a/hexagon/support/yaml/__init__.py
+++ b/hexagon/support/yaml/__init__.py
@@ -2,14 +2,19 @@ from pydantic import ValidationError
 from rich.syntax import Syntax
 from ruamel import yaml
 
-from hexagon.support.printer import log
+from hexagon.support.printer import log, translator
+
+_ = translator
 
 
 def display_yaml_errors(errors: ValidationError, ruamel_yaml=None, yaml_path=None):
     yml = open(yaml_path, "r").read() if yaml_path else None
     errors_as_dict = errors.errors()
     log.error(
-        f"There were {len(errors_as_dict)} error(s) in your YAML file: {yaml_path}"
+        # There were {errors_length} error(s) in your YAML file: {yaml_path}
+        _("error.support.yaml.invalid_yaml").format(
+            errors_length=len(errors_as_dict), yaml_path=yaml_path
+        )
     )
     for err in errors_as_dict:
         log.error(

--- a/locales/en/LC_MESSAGES/hexagon.po
+++ b/locales/en/LC_MESSAGES/hexagon.po
@@ -261,7 +261,7 @@ msgstr ""
 
 #: hexagon/support/update/cli.py:48
 msgid "msg.support.update.cli.new_version_available"
-msgstr "New {cli_start}{cli.name}{cli_end} version available"
+msgstr "New {cli_start}{cli_name}{cli_end} version available"
 
 #: hexagon/support/update/cli.py:53
 msgid "action.support.update.cli.confirm_update"

--- a/locales/en/LC_MESSAGES/hexagon.po
+++ b/locales/en/LC_MESSAGES/hexagon.po
@@ -9,7 +9,7 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -17,7 +17,7 @@ msgstr ""
 
 #: hexagon/__main__.py:37
 msgid "msg.main.first_time_intro"
-msgstr "This looks like your first time running Hexagon."
+msgstr "This looks like your first time running hexagon."
 
 #: hexagon/__main__.py:37
 msgid "msg.main.first_time_tool"
@@ -91,7 +91,7 @@ msgstr "relative to this file"
 
 #: hexagon/actions/internal/install_cli.py:27
 msgid "action.actions.internal.install_cli.config_file_location"
-msgstr "Where is your project's hexagon config file?"
+msgstr "Where is your CLI's hexagon config YAML? (app.yml/yaml)"
 
 #: hexagon/actions/internal/install_cli.py:31
 msgid "error.actions.internal.install_cli.select_valid_file"
@@ -150,7 +150,7 @@ msgstr "Added alias to {file}"
 
 #: hexagon/domain/configuration.py:27
 msgid "msg.domain.configuration.save_alias_long_name"
-msgstr "Save Last Command as Linux Alias"
+msgstr "Save Last Command as Shell Alias"
 
 #: hexagon/domain/configuration.py:33
 msgid "msg.domain.configuration.create_tool_long_name"
@@ -161,7 +161,7 @@ msgid "msg.domain.configuration.install_cli_long_name"
 msgstr "Install CLI"
 
 #: hexagon/domain/configuration.py:106
-msgid "msg.domain.configuration.save_alias_description"
+msgid "msg.domain.configuration.install_cli_description"
 msgstr "Install a custom project CLI from a YAML file."
 
 #: hexagon/support/analytics/__init__.py:78
@@ -240,7 +240,7 @@ msgstr "You are executing Hexagon without an install."
 
 #: hexagon/support/help.py:24
 msgid "msg.support.help.get_started"
-msgstr "To get started run hexagon's \"Install Hexagon\" tool"
+msgstr "To get started run hexagon's \"Install CLI\" tool"
 
 #: hexagon/support/help.py:29
 msgid "msg.global.envs"

--- a/locales/en/LC_MESSAGES/hexagon.po
+++ b/locales/en/LC_MESSAGES/hexagon.po
@@ -1,0 +1,48 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR ORGANIZATION
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2022-01-10 16:12-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+
+#: hexagon/__main__.py:37
+msgid "msg.main.first_time_intro"
+msgstr ""
+
+#: hexagon/__main__.py:37
+msgid "msg.main.first_time_tool"
+msgstr ""
+
+#: hexagon/support/help.py:23
+msgid "msg.support.help.no_install"
+msgstr ""
+
+#: hexagon/support/help.py:24
+msgid "msg.support.help.get_started"
+msgstr ""
+
+#: hexagon/support/wax.py:61
+msgid "action.support.wax.select_environment"
+msgstr ""
+
+#: hexagon/support/wax.py:66
+msgid "error.support.wax.invalid_environment"
+msgstr ""
+
+#: hexagon/support/wax.py:83
+msgid "action.support.wax.select_tool"
+msgstr ""
+
+#: hexagon/support/wax.py:86
+msgid "error.support.wax.invalid_tool"
+msgstr ""

--- a/locales/en/LC_MESSAGES/hexagon.po
+++ b/locales/en/LC_MESSAGES/hexagon.po
@@ -261,7 +261,7 @@ msgstr ""
 
 #: hexagon/support/update/cli.py:48
 msgid "msg.support.update.cli.new_version_available"
-msgstr "New {colors.cli_start}{cli.name}{colors.cli_end} version available"
+msgstr "New {cli_start}{cli.name}{cli_end} version available"
 
 #: hexagon/support/update/cli.py:53
 msgid "action.support.update.cli.confirm_update"

--- a/locales/en/LC_MESSAGES/hexagon.po
+++ b/locales/en/LC_MESSAGES/hexagon.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-10 16:12-0300\n"
+"POT-Creation-Date: 2022-01-16 17:58-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,32 +17,306 @@ msgstr ""
 
 #: hexagon/__main__.py:37
 msgid "msg.main.first_time_intro"
-msgstr ""
+msgstr "This looks like your first time running Hexagon."
 
 #: hexagon/__main__.py:37
 msgid "msg.main.first_time_tool"
+msgstr "You should probably run \"Install CLI\"."
+
+#: hexagon/actions/external/docker_registry.py:30
+msgid "action.actions.external.docker_registry.prompt_docker_image"
+msgstr "What docker image are you looking for?"
+
+#: hexagon/actions/external/docker_registry.py:40
+msgid "action.actions.external.docker_registry.prompt_tag"
+msgstr "Which tag?"
+
+#: hexagon/actions/external/docker_registry.py:53
+msgid "action.actions.external.docker_registry.confirm_see_manifest"
+msgstr "Do you want to see the manifest?"
+
+#: hexagon/actions/external/open_link.py:10
+msgid "msg.actions.external.open_link.result"
+msgstr "Opening URL: {url}"
+
+#: hexagon/actions/internal/create_new_tool.py:20
+msgid "action.actions.internal.create_new_tool.choose_action"
+msgstr "Choose the action of your tool:"
+
+#: hexagon/actions/internal/create_new_tool.py:29
+msgid "action.actions.internal.create_new_tool.input_action"
+msgstr "What name would you like to give your new action?"
+
+#: hexagon/actions/internal/create_new_tool.py:34
+msgid "action.actions.internal.create_new_tool.choose_type"
+msgstr "What type of tool is it?"
+
+#: hexagon/actions/internal/create_new_tool.py:43
+msgid "action.actions.internal.create_new_tool.input_name"
+msgstr "What command would you like to give your tool?"
+
+#: hexagon/actions/internal/create_new_tool.py:49
+msgid "action.actions.internal.create_new_tool.input_alias"
+msgstr "Would you like to add an alias/shortcut? (empty for none)"
+
+#: hexagon/actions/internal/create_new_tool.py:55
+msgid "action.actions.internal.create_new_tool.input_long_name"
 msgstr ""
+"Would you like to add a long name? (this will be displayed instead of "
+"command)"
+
+#: hexagon/actions/internal/create_new_tool.py:60
+msgid "action.actions.internal.create_new_tool.input_description"
+msgstr ""
+"Would you like to add a description? (this will be displayed along side "
+"command/long_name)"
+
+#: hexagon/actions/internal/create_new_tool.py:70
+msgid "msg.actions.internal.create_new_tool.custom_tools_dir_not_set"
+msgstr "Your CLI does not have a custom tools dir."
+
+#: hexagon/actions/internal/create_new_tool.py:75
+msgid "action.actions.internal.create_new_tool.input_custom_tools_path"
+msgstr ""
+"Where would you like it to be? (can be absolute path or relative to YAML. "
+"ie: ./tools or .)"
+
+#: hexagon/actions/internal/create_new_tool.py:81
+msgid "error.actions.internal.create_new_tool.insert_valid_directory"
+msgstr "Please select a valid directory"
+
+#: hexagon/actions/internal/create_new_tool.py:86
+msgid "msg.actions.internal.create_new_tool.input_custom_tools_path_comment"
+msgstr "relative to this file"
+
+#: hexagon/actions/internal/install_cli.py:27
+msgid "action.actions.internal.install_cli.config_file_location"
+msgstr "Where is your project's hexagon config file?"
+
+#: hexagon/actions/internal/install_cli.py:31
+msgid "error.actions.internal.install_cli.select_valid_file"
+msgstr "Please select a valid YAML file"
+
+#: hexagon/actions/internal/install_cli.py:40
+msgid "action.actions.internal.install_cli.commands_path"
+msgstr ""
+"Where do you want your CLI commands to be saved? This should be on your path"
+
+#: hexagon/actions/internal/install_cli.py:44
+msgid "error.actions.internal.install_cli.select_valid_directory"
+msgstr "Please select a valid directory"
+
+#: hexagon/actions/internal/install_cli.py:61
+msgid "msg.actions.internal.install_cli.success"
+msgstr "All done! Now you can execute your project's CLI like:"
+
+#: hexagon/actions/internal/install_cli.py:61
+#: hexagon/actions/internal/save_new_alias.py:61
+#: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:199
+msgid "icon.global.ok"
+msgstr "🗸"
+
+#: hexagon/actions/internal/save_new_alias.py:19
+msgid "msg.actions.internal.save_new_alias.last_command"
+msgstr "Last command: {last_command}"
+
+#: hexagon/actions/internal/save_new_alias.py:25
+msgid "action.actions.internal.save_new_alias.prompt_alias_name"
+msgstr "Alias name?"
+
+#: hexagon/actions/internal/save_new_alias.py:27
+msgid "error.actions.internal.save_new_alias.insert_valid_alias"
+msgstr "Please insert a valid unix alias."
+
+#: hexagon/actions/internal/save_new_alias.py:61
+msgid "msg.actions.internal.save_new_alias.success"
+msgstr "All done! You can now run your alias like:"
+
+#: hexagon/actions/internal/save_new_alias.py:67
+msgid "msg.actions.internal.save_new_alias.execute_tip"
+msgstr "Tip:"
+
+#: hexagon/actions/internal/save_new_alias.py:70
+msgid "msg.actions.internal.save_new_alias.reload_builtins"
+msgstr "You probably need to reload your shell built-ins."
+
+#: hexagon/actions/internal/save_new_alias.py:73
+msgid "msg.actions.internal.save_new_alias.run_source"
+msgstr "Either by running 'source {file_path}' or restarting your terminal."
+
+#: hexagon/actions/internal/save_new_alias.py:82
+msgid "msg.actions.internal.save_new_alias.added_to_file"
+msgstr "Added alias to {file}"
+
+#: hexagon/domain/configuration.py:27
+msgid "msg.domain.configuration.save_alias_long_name"
+msgstr "Save Last Command as Linux Alias"
+
+#: hexagon/domain/configuration.py:33
+msgid "msg.domain.configuration.create_tool_long_name"
+msgstr "Create A New Tool"
+
+#: hexagon/domain/configuration.py:105
+msgid "msg.domain.configuration.install_cli_long_name"
+msgstr "Install CLI"
+
+#: hexagon/domain/configuration.py:106
+msgid "msg.domain.configuration.save_alias_description"
+msgstr "Install a custom project CLI from a YAML file."
+
+#: hexagon/support/analytics/__init__.py:78
+msgid "msg.support.analytics.telemetry_notice"
+msgstr "In order to make Hexagon better we record anonymous usage statistics."
+
+#: hexagon/support/analytics/__init__.py:80
+msgid "msg.support.analytics.telemetry_directory"
+msgstr "You can see what's collected in {directory}"
+
+#: hexagon/support/analytics/__init__.py:86
+msgid "action.support.analytics.confirm_telemetry"
+msgstr "Do you agree to participate?"
+
+#: hexagon/support/cli/git.py:35
+msgid "error.support.cli.git.failed_to_get_remote"
+msgstr ""
+"Couldn't get the remote name from your cli's repository, too many choices "
+"and origin is not present"
+
+#: hexagon/support/execute/action.py:59
+msgid "error.support.execute.action.command_result_code"
+msgstr "{executed_command} returned code: {return_code}"
+
+#: hexagon/support/execute/action.py:67
+msgid "error.support.execute.action.could_not_execute"
+msgstr "Hexagon couldn't execute the action:"
+
+#: hexagon/support/execute/action.py:70
+msgid "error.support.execute.action.we_tried"
+msgstr "We tried:"
+
+#: hexagon/support/execute/action.py:73
+msgid "error.support.execute.action.attempt_cli_custom_dir"
+msgstr "Your CLI's custom_tools_dir:"
+
+#: hexagon/support/execute/action.py:79
+msgid "error.support.execute.action.attempt_internal_tools"
+msgstr "Hexagon repository of external actions"
+
+#: hexagon/support/execute/action.py:84
+msgid "error.support.execute.action.attempt_known_script"
+msgstr "A known script file"
+
+#: hexagon/support/execute/action.py:89
+msgid "error.support.execute.action.attempt_inline_command"
+msgstr "Running your action as a shell command directly"
+
+#: hexagon/support/execute/action.py:112
+msgid "error.support.execute.action.execute_tool_failed"
+msgstr "Execution of tool {action} failed"
+
+#: hexagon/support/execute/action.py:165
+msgid "error.support.execute.action.python_dependency_error"
+msgstr "Your custom action seems to have a module dependency error"
+
+#: hexagon/support/execute/tool.py:79
+msgid "msg.support.execute.tool.go_back_long_name"
+msgstr "Go back"
+
+#: hexagon/support/execute/tool.py:81
+msgid "msg.support.execute.tool.go_back_description"
+msgstr "Go back to the previous menu"
+
+#: hexagon/support/execute/tool.py:82
+msgid "icon.global.go_back"
+msgstr "🠔"
+
+#: hexagon/support/execute/tool.py:101
+msgid "error.support.execute.tool.group_tool_file_not_found"
+msgstr "File {config_file_path} could not be found"
 
 #: hexagon/support/help.py:23
 msgid "msg.support.help.no_install"
-msgstr ""
+msgstr "You are executing Hexagon without an install."
 
 #: hexagon/support/help.py:24
 msgid "msg.support.help.get_started"
+msgstr "To get started run hexagon's \"Install Hexagon\" tool"
+
+#: hexagon/support/help.py:29
+msgid "msg.global.envs"
+msgstr "Envs"
+
+#: hexagon/support/help.py:39
+msgid "msg.global.tools"
+msgstr "Tools"
+
+#: hexagon/support/hooks/hook.py:56
+msgid "error.support.hooks.hook.unknown_type"
+msgstr "Unknown HookSubscriptionType {subscription_type}"
+
+#: hexagon/support/storage.py:86
+msgid "error.support.storage.unsupported_type"
 msgstr ""
+"Type {type} cannot be stored: supported types are str, List[str] or Dict"
+
+#: hexagon/support/update/cli.py:48
+msgid "msg.support.update.cli.new_version_available"
+msgstr "New {colors.cli_start}{cli.name}{colors.cli_end} version available"
+
+#: hexagon/support/update/cli.py:53
+msgid "action.support.update.cli.confirm_update"
+msgstr "Would you like to update?"
+
+#: hexagon/support/update/cli.py:59
+msgid "msg.support.update.cli.updated"
+msgstr "Updated to latest version"
+
+#: hexagon/support/update/hexagon.py:135
+msgid "msg.support.update.hexagon.fetching_changelog"
+msgstr "Fetching changelog"
+
+#: hexagon/support/update/hexagon.py:151
+msgid "msg.support.update.hexagon.and_much_more"
+msgstr "and much more!"
+
+#: hexagon/support/update/hexagon.py:172
+msgid "msg.support.update.hexagon.new_version_available"
+msgstr ""
+"New {colors.hexagon_start}hexagon{colors.hexagon_end} version available "
+"{colors.version_start}{latest_version}{colors.version_end}!"
+
+#: hexagon/support/update/hexagon.py:186
+msgid "action.support.update.hexagon.confirm_update"
+msgstr "Would you like to update?"
+
+#: hexagon/support/update/hexagon.py:190
+msgid "msg.support.update.hexagon.updating"
+msgstr "Updating"
+
+#: hexagon/support/update/hexagon.py:199
+msgid "msg.support.update.hexagon.updated"
+msgstr "Updated to latest version"
+
+#: hexagon/support/update/hexagon.py:207
+msgid "msg.support.update.hexagon.checking_new_versions"
+msgstr "Checking for new hexagon versions"
 
 #: hexagon/support/wax.py:61
 msgid "action.support.wax.select_environment"
-msgstr ""
+msgstr "On which environment?"
 
 #: hexagon/support/wax.py:66
 msgid "error.support.wax.invalid_environment"
-msgstr ""
+msgstr "Please select a valid environment"
 
 #: hexagon/support/wax.py:83
 msgid "action.support.wax.select_tool"
-msgstr ""
+msgstr "Hi, which tool would you like to use today?"
 
 #: hexagon/support/wax.py:86
 msgid "error.support.wax.invalid_tool"
-msgstr ""
+msgstr "Please select a valid tool"
+
+#: hexagon/support/yaml/__init__.py:15
+msgid "error.support.yaml.invalid_yaml"
+msgstr "There were {errors_length} error(s) in your YAML file: {yaml_path}"

--- a/locales/en/LC_MESSAGES/hexagon.po
+++ b/locales/en/LC_MESSAGES/hexagon.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-16 17:58-0300\n"
+"POT-Creation-Date: 2022-01-18 00:32-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -112,7 +112,7 @@ msgstr "All done! Now you can execute your project's CLI like:"
 
 #: hexagon/actions/internal/install_cli.py:61
 #: hexagon/actions/internal/save_new_alias.py:61
-#: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:199
+#: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:197
 msgid "icon.global.ok"
 msgstr "🗸"
 
@@ -282,22 +282,22 @@ msgstr "and much more!"
 #: hexagon/support/update/hexagon.py:172
 msgid "msg.support.update.hexagon.new_version_available"
 msgstr ""
-"New {colors.hexagon_start}hexagon{colors.hexagon_end} version available "
-"{colors.version_start}{latest_version}{colors.version_end}!"
+"New {hexagon_start}hexagon{hexagon_end} version available {version_start}"
+"{latest_version}{version_end}!"
 
-#: hexagon/support/update/hexagon.py:186
+#: hexagon/support/update/hexagon.py:184
 msgid "action.support.update.hexagon.confirm_update"
 msgstr "Would you like to update?"
 
-#: hexagon/support/update/hexagon.py:190
+#: hexagon/support/update/hexagon.py:188
 msgid "msg.support.update.hexagon.updating"
 msgstr "Updating"
 
-#: hexagon/support/update/hexagon.py:199
+#: hexagon/support/update/hexagon.py:197
 msgid "msg.support.update.hexagon.updated"
 msgstr "Updated to latest version"
 
-#: hexagon/support/update/hexagon.py:207
+#: hexagon/support/update/hexagon.py:205
 msgid "msg.support.update.hexagon.checking_new_versions"
 msgstr "Checking for new hexagon versions"
 

--- a/locales/es/LC_MESSAGES/hexagon.po
+++ b/locales/es/LC_MESSAGES/hexagon.po
@@ -1,0 +1,53 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR ORGANIZATION
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2022-01-10 16:12-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+
+#: hexagon/__main__.py:37
+#, fuzzy
+msgid "msg.main.first_time_intro"
+msgstr "asfads"
+
+#: hexagon/__main__.py:37
+#, fuzzy
+msgid "msg.main.first_time_tool"
+msgstr "asfads"
+
+#: hexagon/support/help.py:23
+msgid "msg.support.help.no_install"
+msgstr ""
+
+#: hexagon/support/help.py:24
+msgid "msg.support.help.get_started"
+msgstr ""
+
+#: hexagon/support/wax.py:61
+msgid "action.support.wax.select_environment"
+msgstr ""
+
+#: hexagon/support/wax.py:66
+msgid "error.support.wax.invalid_environment"
+msgstr ""
+
+#: hexagon/support/wax.py:83
+msgid "action.support.wax.select_tool"
+msgstr ""
+
+#: hexagon/support/wax.py:86
+msgid "error.support.wax.invalid_tool"
+msgstr ""
+
+#~ msgid "info.title.first_time"
+#~ msgstr " asdcasdf asdfs "

--- a/locales/es/LC_MESSAGES/hexagon.po
+++ b/locales/es/LC_MESSAGES/hexagon.po
@@ -310,6 +310,3 @@ msgstr ""
 #: hexagon/support/yaml/__init__.py:15
 msgid "error.support.yaml.invalid_yaml"
 msgstr ""
-
-#~ msgid "info.title.first_time"
-#~ msgstr " asdcasdf asdfs "

--- a/locales/es/LC_MESSAGES/hexagon.po
+++ b/locales/es/LC_MESSAGES/hexagon.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-16 17:58-0300\n"
+"POT-Creation-Date: 2022-01-18 00:32-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -107,7 +107,7 @@ msgstr ""
 
 #: hexagon/actions/internal/install_cli.py:61
 #: hexagon/actions/internal/save_new_alias.py:61
-#: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:199
+#: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:197
 msgid "icon.global.ok"
 msgstr ""
 
@@ -275,19 +275,19 @@ msgstr ""
 msgid "msg.support.update.hexagon.new_version_available"
 msgstr ""
 
-#: hexagon/support/update/hexagon.py:186
+#: hexagon/support/update/hexagon.py:184
 msgid "action.support.update.hexagon.confirm_update"
 msgstr ""
 
-#: hexagon/support/update/hexagon.py:190
+#: hexagon/support/update/hexagon.py:188
 msgid "msg.support.update.hexagon.updating"
 msgstr ""
 
-#: hexagon/support/update/hexagon.py:199
+#: hexagon/support/update/hexagon.py:197
 msgid "msg.support.update.hexagon.updated"
 msgstr ""
 
-#: hexagon/support/update/hexagon.py:207
+#: hexagon/support/update/hexagon.py:205
 msgid "msg.support.update.hexagon.checking_new_versions"
 msgstr ""
 

--- a/locales/es/LC_MESSAGES/hexagon.po
+++ b/locales/es/LC_MESSAGES/hexagon.po
@@ -9,304 +9,302 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: pygettext.py 1.5\n"
 
 #: hexagon/__main__.py:37
-#, fuzzy
 msgid "msg.main.first_time_intro"
-msgstr "asfads"
+msgstr "Esta parece ser tu primera vez ejecutando hexagon."
 
 #: hexagon/__main__.py:37
-#, fuzzy
 msgid "msg.main.first_time_tool"
-msgstr "asfads"
+msgstr "Probablemente deberías ejecutar \"Instalar CLI\""
 
 #: hexagon/actions/external/docker_registry.py:30
 msgid "action.actions.external.docker_registry.prompt_docker_image"
-msgstr ""
+msgstr "¿Qué imagen de docker estás buscando?"
 
 #: hexagon/actions/external/docker_registry.py:40
 msgid "action.actions.external.docker_registry.prompt_tag"
-msgstr ""
+msgstr "¿Qué tag?"
 
 #: hexagon/actions/external/docker_registry.py:53
 msgid "action.actions.external.docker_registry.confirm_see_manifest"
-msgstr ""
+msgstr "¿Te gustaría ver el manifest?"
 
 #: hexagon/actions/external/open_link.py:10
 msgid "msg.actions.external.open_link.result"
-msgstr ""
+msgstr "Abriendo URL: {url}"
 
 #: hexagon/actions/internal/create_new_tool.py:20
 msgid "action.actions.internal.create_new_tool.choose_action"
-msgstr ""
+msgstr "Seleccioná la acción que va a tener tu herramienta:"
 
 #: hexagon/actions/internal/create_new_tool.py:29
 msgid "action.actions.internal.create_new_tool.input_action"
-msgstr ""
+msgstr "¿Qué nombre va a tener tu acción?"
 
 #: hexagon/actions/internal/create_new_tool.py:34
 msgid "action.actions.internal.create_new_tool.choose_type"
-msgstr ""
+msgstr "¿Cual es el tipo de la herramienta?"
 
 #: hexagon/actions/internal/create_new_tool.py:43
 msgid "action.actions.internal.create_new_tool.input_name"
-msgstr ""
+msgstr "¿Qué comando va a tener tu herramienta?"
 
 #: hexagon/actions/internal/create_new_tool.py:49
 msgid "action.actions.internal.create_new_tool.input_alias"
-msgstr ""
+msgstr "¿Te gustaría que tenga un alias? (vacío = No)"
 
 #: hexagon/actions/internal/create_new_tool.py:55
 msgid "action.actions.internal.create_new_tool.input_long_name"
-msgstr ""
+msgstr "¿Te gustaría agregar un nombre más descriptivo? (va a ser mostrado en lugar del comando)"
 
 #: hexagon/actions/internal/create_new_tool.py:60
 msgid "action.actions.internal.create_new_tool.input_description"
-msgstr ""
+msgstr "¿Te gustaría agregar una descripción? (va a ser mostrada junto con el nombre/comando)"
 
 #: hexagon/actions/internal/create_new_tool.py:70
 msgid "msg.actions.internal.create_new_tool.custom_tools_dir_not_set"
-msgstr ""
+msgstr "Tu CLI no tiene un directorio de herramientas (cli.custom_tools_dir)."
 
 #: hexagon/actions/internal/create_new_tool.py:75
 msgid "action.actions.internal.create_new_tool.input_custom_tools_path"
-msgstr ""
+msgstr "¿Donde te gustaría que se encuentre? (puede ser un directorio relativo al YAML - ej: ./tools o . - o absoluto)"
 
 #: hexagon/actions/internal/create_new_tool.py:81
 msgid "error.actions.internal.create_new_tool.insert_valid_directory"
-msgstr ""
+msgstr "Por favor, ingresar un directorio valido"
 
 #: hexagon/actions/internal/create_new_tool.py:86
 msgid "msg.actions.internal.create_new_tool.input_custom_tools_path_comment"
-msgstr ""
+msgstr "relativo a este archivo"
 
 #: hexagon/actions/internal/install_cli.py:27
 msgid "action.actions.internal.install_cli.config_file_location"
-msgstr ""
+msgstr "¿Dónde está el YAML de configuración de tu CLI? (*.yml o *.yaml)"
 
 #: hexagon/actions/internal/install_cli.py:31
 msgid "error.actions.internal.install_cli.select_valid_file"
-msgstr ""
+msgstr "Por favor, selecciona un YAML valido (*.yaml o *.yml)"
 
 #: hexagon/actions/internal/install_cli.py:40
 msgid "action.actions.internal.install_cli.commands_path"
-msgstr ""
+msgstr "¿En qué directorio te gustaría que se guarden los comandos de CLI? Debería estar en el PATH de tu SO."
 
 #: hexagon/actions/internal/install_cli.py:44
 msgid "error.actions.internal.install_cli.select_valid_directory"
-msgstr ""
+msgstr "Por favor, ingresar un directorio valido"
 
 #: hexagon/actions/internal/install_cli.py:61
 msgid "msg.actions.internal.install_cli.success"
-msgstr ""
+msgstr "¡Listo! Ahora podes ejecutar tu CLI de la siguiente manera:"
 
 #: hexagon/actions/internal/install_cli.py:61
 #: hexagon/actions/internal/save_new_alias.py:61
 #: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:197
 msgid "icon.global.ok"
-msgstr ""
+msgstr "🗸"
 
 #: hexagon/actions/internal/save_new_alias.py:19
 msgid "msg.actions.internal.save_new_alias.last_command"
-msgstr ""
+msgstr "Último comando ejecutado: {last_command}"
 
 #: hexagon/actions/internal/save_new_alias.py:25
 msgid "action.actions.internal.save_new_alias.prompt_alias_name"
-msgstr ""
+msgstr "¿qué alias se quiere usar?"
 
 #: hexagon/actions/internal/save_new_alias.py:27
 msgid "error.actions.internal.save_new_alias.insert_valid_alias"
-msgstr ""
+msgstr "Por favor, ingresar un alias de shell valido."
 
 #: hexagon/actions/internal/save_new_alias.py:61
 msgid "msg.actions.internal.save_new_alias.success"
-msgstr ""
+msgstr "¡Listo! Ya podés ejecutar tu alias de la siguiente manera:"
 
 #: hexagon/actions/internal/save_new_alias.py:67
 msgid "msg.actions.internal.save_new_alias.execute_tip"
-msgstr ""
+msgstr "Tip:"
 
 #: hexagon/actions/internal/save_new_alias.py:70
 msgid "msg.actions.internal.save_new_alias.reload_builtins"
-msgstr ""
+msgstr "Probablemente necesites refrescar los built-ins de tu shell."
 
 #: hexagon/actions/internal/save_new_alias.py:73
 msgid "msg.actions.internal.save_new_alias.run_source"
-msgstr ""
+msgstr "Podes ejecutar 'source {file_path}' o reiniciar tu terminal."
 
 #: hexagon/actions/internal/save_new_alias.py:82
 msgid "msg.actions.internal.save_new_alias.added_to_file"
-msgstr ""
+msgstr "Se agrego el alias al archivo {file}"
 
 #: hexagon/domain/configuration.py:27
 msgid "msg.domain.configuration.save_alias_long_name"
-msgstr ""
+msgstr "Guardar el último comando ejecutado como shell alias"
 
 #: hexagon/domain/configuration.py:33
 msgid "msg.domain.configuration.create_tool_long_name"
-msgstr ""
+msgstr "Crear una nueva herramienta"
 
 #: hexagon/domain/configuration.py:105
 msgid "msg.domain.configuration.install_cli_long_name"
-msgstr ""
+msgstr "Instalar CLI"
 
 #: hexagon/domain/configuration.py:106
-msgid "msg.domain.configuration.save_alias_description"
-msgstr ""
+msgid "msg.domain.configuration.install_cli_description"
+msgstr "Instalar una CLI desde un archivo YAML de configuración."
 
 #: hexagon/support/analytics/__init__.py:78
 msgid "msg.support.analytics.telemetry_notice"
-msgstr ""
+msgstr "Para poder mejorar la experiencia de hexagon registramos eventos anónimos de uso."
 
 #: hexagon/support/analytics/__init__.py:80
 msgid "msg.support.analytics.telemetry_directory"
-msgstr ""
+msgstr "Podés ver que se registra en {directory}"
 
 #: hexagon/support/analytics/__init__.py:86
 msgid "action.support.analytics.confirm_telemetry"
-msgstr ""
+msgstr "¿Te gustaría participar enviando estos datos?"
 
 #: hexagon/support/cli/git.py:35
 msgid "error.support.cli.git.failed_to_get_remote"
-msgstr ""
+msgstr "Hubo un error de git accediendo al remote del repositorio de tu CLI, hay varias opciones y origin no está presente."
 
 #: hexagon/support/execute/action.py:59
 msgid "error.support.execute.action.command_result_code"
-msgstr ""
+msgstr "{executed_command} returned code: {return_code}"
 
 #: hexagon/support/execute/action.py:67
 msgid "error.support.execute.action.could_not_execute"
-msgstr ""
+msgstr "No fue posible ejecutar la acción:"
 
 #: hexagon/support/execute/action.py:70
 msgid "error.support.execute.action.we_tried"
-msgstr ""
+msgstr "Intentamos lo siguiente:"
 
 #: hexagon/support/execute/action.py:73
 msgid "error.support.execute.action.attempt_cli_custom_dir"
-msgstr ""
+msgstr "Buscar la acción en tu directorio de herramientas (custom_tools_dir)"
 
 #: hexagon/support/execute/action.py:79
 msgid "error.support.execute.action.attempt_internal_tools"
-msgstr ""
+msgstr "Buscar en el registro interno de acciones de hexagon"
 
 #: hexagon/support/execute/action.py:84
 msgid "error.support.execute.action.attempt_known_script"
-msgstr ""
+msgstr "Ejecutar según extensiones conocidas de archivos"
 
 #: hexagon/support/execute/action.py:89
 msgid "error.support.execute.action.attempt_inline_command"
-msgstr ""
+msgstr "Ejecutando la acción como un comando directamente"
 
 #: hexagon/support/execute/action.py:112
 msgid "error.support.execute.action.execute_tool_failed"
-msgstr ""
+msgstr "La ejecución de {action} falló"
 
 #: hexagon/support/execute/action.py:165
 msgid "error.support.execute.action.python_dependency_error"
-msgstr ""
+msgstr "Tu acción parece tener un error de dependencias de módulos"
 
 #: hexagon/support/execute/tool.py:79
 msgid "msg.support.execute.tool.go_back_long_name"
-msgstr ""
+msgstr "Atrás"
 
 #: hexagon/support/execute/tool.py:81
 msgid "msg.support.execute.tool.go_back_description"
-msgstr ""
+msgstr "Volver al menú anterior"
 
 #: hexagon/support/execute/tool.py:82
 msgid "icon.global.go_back"
-msgstr ""
+msgstr "🠔"
 
 #: hexagon/support/execute/tool.py:101
 msgid "error.support.execute.tool.group_tool_file_not_found"
-msgstr ""
+msgstr "No se encontró el archivo {config_file_path}"
 
 #: hexagon/support/help.py:23
 msgid "msg.support.help.no_install"
-msgstr ""
+msgstr "Se está ejecutando hexagon directamente."
 
 #: hexagon/support/help.py:24
 msgid "msg.support.help.get_started"
-msgstr ""
+msgstr "El primer paso suele ser ejecutar la acción \"Instalar CLI\"."
 
 #: hexagon/support/help.py:29
 msgid "msg.global.envs"
-msgstr ""
+msgstr "Entornos"
 
 #: hexagon/support/help.py:39
 msgid "msg.global.tools"
-msgstr ""
+msgstr "Herramientas"
 
 #: hexagon/support/hooks/hook.py:56
 msgid "error.support.hooks.hook.unknown_type"
-msgstr ""
+msgstr "HookSubscriptionType desconocido {subscription_type}"
 
 #: hexagon/support/storage.py:86
 msgid "error.support.storage.unsupported_type"
-msgstr ""
+msgstr "El tipo {type} no se puede guardar: los tipos soportados son str, List[str] or Dict"
 
 #: hexagon/support/update/cli.py:48
 msgid "msg.support.update.cli.new_version_available"
-msgstr ""
+msgstr "Hay una nueva versión disponible de {cli_start}{cli_name}{cli_end}"
 
 #: hexagon/support/update/cli.py:53
 msgid "action.support.update.cli.confirm_update"
-msgstr ""
+msgstr "¿Te gustaría actualizar?"
 
 #: hexagon/support/update/cli.py:59
 msgid "msg.support.update.cli.updated"
-msgstr ""
+msgstr "Se actualizó a la última versión"
 
 #: hexagon/support/update/hexagon.py:135
 msgid "msg.support.update.hexagon.fetching_changelog"
-msgstr ""
+msgstr "Descargando información de cambios"
 
 #: hexagon/support/update/hexagon.py:151
 msgid "msg.support.update.hexagon.and_much_more"
-msgstr ""
+msgstr "¡y mucho más!"
 
 #: hexagon/support/update/hexagon.py:172
 msgid "msg.support.update.hexagon.new_version_available"
-msgstr ""
+msgstr "¡Existe una nueva versión {version_start}{latest_version}{version_end} de {hexagon_start}hexagon{hexagon_end}!"
 
 #: hexagon/support/update/hexagon.py:184
 msgid "action.support.update.hexagon.confirm_update"
-msgstr ""
+msgstr "¿Te gustaría actualizar?"
 
 #: hexagon/support/update/hexagon.py:188
 msgid "msg.support.update.hexagon.updating"
-msgstr ""
+msgstr "Actualizando"
 
 #: hexagon/support/update/hexagon.py:197
 msgid "msg.support.update.hexagon.updated"
-msgstr ""
+msgstr "Se actualizó a la última versión"
 
 #: hexagon/support/update/hexagon.py:205
 msgid "msg.support.update.hexagon.checking_new_versions"
-msgstr ""
+msgstr "Verificando si existen nuevas versión de hexagon"
 
 #: hexagon/support/wax.py:61
 msgid "action.support.wax.select_environment"
-msgstr ""
+msgstr "¿Para qué entorno?"
 
 #: hexagon/support/wax.py:66
 msgid "error.support.wax.invalid_environment"
-msgstr ""
+msgstr "Por favor, selecciona un entorno valido"
 
 #: hexagon/support/wax.py:83
 msgid "action.support.wax.select_tool"
-msgstr ""
+msgstr "Hola ¿qué herramienta te gustaría usar hoy?"
 
 #: hexagon/support/wax.py:86
 msgid "error.support.wax.invalid_tool"
-msgstr ""
+msgstr "Por favor, selecciona una herramienta valida"
 
 #: hexagon/support/yaml/__init__.py:15
 msgid "error.support.yaml.invalid_yaml"
-msgstr ""
+msgstr "Hay {errors_length} errores en el YAML: {yaml_path}"

--- a/locales/es/LC_MESSAGES/hexagon.po
+++ b/locales/es/LC_MESSAGES/hexagon.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-10 16:12-0300\n"
+"POT-Creation-Date: 2022-01-16 17:58-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,12 +25,270 @@ msgstr "asfads"
 msgid "msg.main.first_time_tool"
 msgstr "asfads"
 
+#: hexagon/actions/external/docker_registry.py:30
+msgid "action.actions.external.docker_registry.prompt_docker_image"
+msgstr ""
+
+#: hexagon/actions/external/docker_registry.py:40
+msgid "action.actions.external.docker_registry.prompt_tag"
+msgstr ""
+
+#: hexagon/actions/external/docker_registry.py:53
+msgid "action.actions.external.docker_registry.confirm_see_manifest"
+msgstr ""
+
+#: hexagon/actions/external/open_link.py:10
+msgid "msg.actions.external.open_link.result"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:20
+msgid "action.actions.internal.create_new_tool.choose_action"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:29
+msgid "action.actions.internal.create_new_tool.input_action"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:34
+msgid "action.actions.internal.create_new_tool.choose_type"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:43
+msgid "action.actions.internal.create_new_tool.input_name"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:49
+msgid "action.actions.internal.create_new_tool.input_alias"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:55
+msgid "action.actions.internal.create_new_tool.input_long_name"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:60
+msgid "action.actions.internal.create_new_tool.input_description"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:70
+msgid "msg.actions.internal.create_new_tool.custom_tools_dir_not_set"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:75
+msgid "action.actions.internal.create_new_tool.input_custom_tools_path"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:81
+msgid "error.actions.internal.create_new_tool.insert_valid_directory"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:86
+msgid "msg.actions.internal.create_new_tool.input_custom_tools_path_comment"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:27
+msgid "action.actions.internal.install_cli.config_file_location"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:31
+msgid "error.actions.internal.install_cli.select_valid_file"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:40
+msgid "action.actions.internal.install_cli.commands_path"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:44
+msgid "error.actions.internal.install_cli.select_valid_directory"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:61
+msgid "msg.actions.internal.install_cli.success"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:61
+#: hexagon/actions/internal/save_new_alias.py:61
+#: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:199
+msgid "icon.global.ok"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:19
+msgid "msg.actions.internal.save_new_alias.last_command"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:25
+msgid "action.actions.internal.save_new_alias.prompt_alias_name"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:27
+msgid "error.actions.internal.save_new_alias.insert_valid_alias"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:61
+msgid "msg.actions.internal.save_new_alias.success"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:67
+msgid "msg.actions.internal.save_new_alias.execute_tip"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:70
+msgid "msg.actions.internal.save_new_alias.reload_builtins"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:73
+msgid "msg.actions.internal.save_new_alias.run_source"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:82
+msgid "msg.actions.internal.save_new_alias.added_to_file"
+msgstr ""
+
+#: hexagon/domain/configuration.py:27
+msgid "msg.domain.configuration.save_alias_long_name"
+msgstr ""
+
+#: hexagon/domain/configuration.py:33
+msgid "msg.domain.configuration.create_tool_long_name"
+msgstr ""
+
+#: hexagon/domain/configuration.py:105
+msgid "msg.domain.configuration.install_cli_long_name"
+msgstr ""
+
+#: hexagon/domain/configuration.py:106
+msgid "msg.domain.configuration.save_alias_description"
+msgstr ""
+
+#: hexagon/support/analytics/__init__.py:78
+msgid "msg.support.analytics.telemetry_notice"
+msgstr ""
+
+#: hexagon/support/analytics/__init__.py:80
+msgid "msg.support.analytics.telemetry_directory"
+msgstr ""
+
+#: hexagon/support/analytics/__init__.py:86
+msgid "action.support.analytics.confirm_telemetry"
+msgstr ""
+
+#: hexagon/support/cli/git.py:35
+msgid "error.support.cli.git.failed_to_get_remote"
+msgstr ""
+
+#: hexagon/support/execute/action.py:59
+msgid "error.support.execute.action.command_result_code"
+msgstr ""
+
+#: hexagon/support/execute/action.py:67
+msgid "error.support.execute.action.could_not_execute"
+msgstr ""
+
+#: hexagon/support/execute/action.py:70
+msgid "error.support.execute.action.we_tried"
+msgstr ""
+
+#: hexagon/support/execute/action.py:73
+msgid "error.support.execute.action.attempt_cli_custom_dir"
+msgstr ""
+
+#: hexagon/support/execute/action.py:79
+msgid "error.support.execute.action.attempt_internal_tools"
+msgstr ""
+
+#: hexagon/support/execute/action.py:84
+msgid "error.support.execute.action.attempt_known_script"
+msgstr ""
+
+#: hexagon/support/execute/action.py:89
+msgid "error.support.execute.action.attempt_inline_command"
+msgstr ""
+
+#: hexagon/support/execute/action.py:112
+msgid "error.support.execute.action.execute_tool_failed"
+msgstr ""
+
+#: hexagon/support/execute/action.py:165
+msgid "error.support.execute.action.python_dependency_error"
+msgstr ""
+
+#: hexagon/support/execute/tool.py:79
+msgid "msg.support.execute.tool.go_back_long_name"
+msgstr ""
+
+#: hexagon/support/execute/tool.py:81
+msgid "msg.support.execute.tool.go_back_description"
+msgstr ""
+
+#: hexagon/support/execute/tool.py:82
+msgid "icon.global.go_back"
+msgstr ""
+
+#: hexagon/support/execute/tool.py:101
+msgid "error.support.execute.tool.group_tool_file_not_found"
+msgstr ""
+
 #: hexagon/support/help.py:23
 msgid "msg.support.help.no_install"
 msgstr ""
 
 #: hexagon/support/help.py:24
 msgid "msg.support.help.get_started"
+msgstr ""
+
+#: hexagon/support/help.py:29
+msgid "msg.global.envs"
+msgstr ""
+
+#: hexagon/support/help.py:39
+msgid "msg.global.tools"
+msgstr ""
+
+#: hexagon/support/hooks/hook.py:56
+msgid "error.support.hooks.hook.unknown_type"
+msgstr ""
+
+#: hexagon/support/storage.py:86
+msgid "error.support.storage.unsupported_type"
+msgstr ""
+
+#: hexagon/support/update/cli.py:48
+msgid "msg.support.update.cli.new_version_available"
+msgstr ""
+
+#: hexagon/support/update/cli.py:53
+msgid "action.support.update.cli.confirm_update"
+msgstr ""
+
+#: hexagon/support/update/cli.py:59
+msgid "msg.support.update.cli.updated"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:135
+msgid "msg.support.update.hexagon.fetching_changelog"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:151
+msgid "msg.support.update.hexagon.and_much_more"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:172
+msgid "msg.support.update.hexagon.new_version_available"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:186
+msgid "action.support.update.hexagon.confirm_update"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:190
+msgid "msg.support.update.hexagon.updating"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:199
+msgid "msg.support.update.hexagon.updated"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:207
+msgid "msg.support.update.hexagon.checking_new_versions"
 msgstr ""
 
 #: hexagon/support/wax.py:61
@@ -47,6 +305,10 @@ msgstr ""
 
 #: hexagon/support/wax.py:86
 msgid "error.support.wax.invalid_tool"
+msgstr ""
+
+#: hexagon/support/yaml/__init__.py:15
+msgid "error.support.yaml.invalid_yaml"
 msgstr ""
 
 #~ msgid "info.title.first_time"

--- a/locales/hexagon.pot
+++ b/locales/hexagon.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-18 12:00-0300\n"
+"POT-Creation-Date: 2022-01-19 18:36-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -154,7 +154,7 @@ msgid "msg.domain.configuration.install_cli_long_name"
 msgstr ""
 
 #: hexagon/domain/configuration.py:106
-msgid "msg.domain.configuration.save_alias_description"
+msgid "msg.domain.configuration.install_cli_description"
 msgstr ""
 
 #: hexagon/support/analytics/__init__.py:78

--- a/locales/hexagon.pot
+++ b/locales/hexagon.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-18 00:43-0300\n"
+"POT-Creation-Date: 2022-01-18 12:00-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/locales/hexagon.pot
+++ b/locales/hexagon.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-18 00:32-0300\n"
+"POT-Creation-Date: 2022-01-18 00:43-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/locales/hexagon.pot
+++ b/locales/hexagon.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-16 18:00-0300\n"
+"POT-Creation-Date: 2022-01-16 19:49-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/locales/hexagon.pot
+++ b/locales/hexagon.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-16 12:05-0300\n"
+"POT-Creation-Date: 2022-01-16 18:00-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -67,15 +67,19 @@ msgstr ""
 msgid "action.actions.internal.create_new_tool.input_description"
 msgstr ""
 
-#: hexagon/actions/internal/create_new_tool.py:73
+#: hexagon/actions/internal/create_new_tool.py:70
+msgid "msg.actions.internal.create_new_tool.custom_tools_dir_not_set"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:75
 msgid "action.actions.internal.create_new_tool.input_custom_tools_path"
 msgstr ""
 
-#: hexagon/actions/internal/create_new_tool.py:79
+#: hexagon/actions/internal/create_new_tool.py:81
 msgid "error.actions.internal.create_new_tool.insert_valid_directory"
 msgstr ""
 
-#: hexagon/actions/internal/create_new_tool.py:84
+#: hexagon/actions/internal/create_new_tool.py:86
 msgid "msg.actions.internal.create_new_tool.input_custom_tools_path_comment"
 msgstr ""
 
@@ -95,16 +99,46 @@ msgstr ""
 msgid "error.actions.internal.install_cli.select_valid_directory"
 msgstr ""
 
-#: hexagon/actions/internal/save_new_alias.py:20
+#: hexagon/actions/internal/install_cli.py:61
+msgid "msg.actions.internal.install_cli.success"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:61
+#: hexagon/actions/internal/save_new_alias.py:61
+#: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:199
+msgid "icon.global.ok"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:19
 msgid "msg.actions.internal.save_new_alias.last_command"
 msgstr ""
 
-#: hexagon/actions/internal/save_new_alias.py:26
+#: hexagon/actions/internal/save_new_alias.py:25
 msgid "action.actions.internal.save_new_alias.prompt_alias_name"
 msgstr ""
 
-#: hexagon/actions/internal/save_new_alias.py:28
+#: hexagon/actions/internal/save_new_alias.py:27
 msgid "error.actions.internal.save_new_alias.insert_valid_alias"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:61
+msgid "msg.actions.internal.save_new_alias.success"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:67
+msgid "msg.actions.internal.save_new_alias.execute_tip"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:70
+msgid "msg.actions.internal.save_new_alias.reload_builtins"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:73
+msgid "msg.actions.internal.save_new_alias.run_source"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:82
+msgid "msg.actions.internal.save_new_alias.added_to_file"
 msgstr ""
 
 #: hexagon/domain/configuration.py:27
@@ -135,7 +169,7 @@ msgstr ""
 msgid "action.support.analytics.confirm_telemetry"
 msgstr ""
 
-#: hexagon/support/cli/git.py:33
+#: hexagon/support/cli/git.py:35
 msgid "error.support.cli.git.failed_to_get_remote"
 msgstr ""
 
@@ -143,11 +177,35 @@ msgstr ""
 msgid "error.support.execute.action.command_result_code"
 msgstr ""
 
-#: hexagon/support/execute/action.py:68
+#: hexagon/support/execute/action.py:67
+msgid "error.support.execute.action.could_not_execute"
+msgstr ""
+
+#: hexagon/support/execute/action.py:70
 msgid "error.support.execute.action.we_tried"
 msgstr ""
 
-#: hexagon/support/execute/action.py:150
+#: hexagon/support/execute/action.py:73
+msgid "error.support.execute.action.attempt_cli_custom_dir"
+msgstr ""
+
+#: hexagon/support/execute/action.py:79
+msgid "error.support.execute.action.attempt_internal_tools"
+msgstr ""
+
+#: hexagon/support/execute/action.py:84
+msgid "error.support.execute.action.attempt_known_script"
+msgstr ""
+
+#: hexagon/support/execute/action.py:89
+msgid "error.support.execute.action.attempt_inline_command"
+msgstr ""
+
+#: hexagon/support/execute/action.py:112
+msgid "error.support.execute.action.execute_tool_failed"
+msgstr ""
+
+#: hexagon/support/execute/action.py:165
 msgid "error.support.execute.action.python_dependency_error"
 msgstr ""
 
@@ -175,6 +233,14 @@ msgstr ""
 msgid "msg.support.help.get_started"
 msgstr ""
 
+#: hexagon/support/help.py:29
+msgid "msg.global.envs"
+msgstr ""
+
+#: hexagon/support/help.py:39
+msgid "msg.global.tools"
+msgstr ""
+
 #: hexagon/support/hooks/hook.py:56
 msgid "error.support.hooks.hook.unknown_type"
 msgstr ""
@@ -183,8 +249,16 @@ msgstr ""
 msgid "error.support.storage.unsupported_type"
 msgstr ""
 
-#: hexagon/support/update/cli.py:49
+#: hexagon/support/update/cli.py:48
 msgid "msg.support.update.cli.new_version_available"
+msgstr ""
+
+#: hexagon/support/update/cli.py:53
+msgid "action.support.update.cli.confirm_update"
+msgstr ""
+
+#: hexagon/support/update/cli.py:59
+msgid "msg.support.update.cli.updated"
 msgstr ""
 
 #: hexagon/support/update/hexagon.py:135
@@ -207,7 +281,11 @@ msgstr ""
 msgid "msg.support.update.hexagon.updating"
 msgstr ""
 
-#: hexagon/support/update/hexagon.py:205
+#: hexagon/support/update/hexagon.py:199
+msgid "msg.support.update.hexagon.updated"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:207
 msgid "msg.support.update.hexagon.checking_new_versions"
 msgstr ""
 

--- a/locales/hexagon.pot
+++ b/locales/hexagon.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-16 19:49-0300\n"
+"POT-Creation-Date: 2022-01-18 00:32-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -105,7 +105,7 @@ msgstr ""
 
 #: hexagon/actions/internal/install_cli.py:61
 #: hexagon/actions/internal/save_new_alias.py:61
-#: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:199
+#: hexagon/support/update/cli.py:59 hexagon/support/update/hexagon.py:197
 msgid "icon.global.ok"
 msgstr ""
 
@@ -273,19 +273,19 @@ msgstr ""
 msgid "msg.support.update.hexagon.new_version_available"
 msgstr ""
 
-#: hexagon/support/update/hexagon.py:186
+#: hexagon/support/update/hexagon.py:184
 msgid "action.support.update.hexagon.confirm_update"
 msgstr ""
 
-#: hexagon/support/update/hexagon.py:190
+#: hexagon/support/update/hexagon.py:188
 msgid "msg.support.update.hexagon.updating"
 msgstr ""
 
-#: hexagon/support/update/hexagon.py:199
+#: hexagon/support/update/hexagon.py:197
 msgid "msg.support.update.hexagon.updated"
 msgstr ""
 
-#: hexagon/support/update/hexagon.py:207
+#: hexagon/support/update/hexagon.py:205
 msgid "msg.support.update.hexagon.checking_new_versions"
 msgstr ""
 

--- a/locales/hexagon.pot
+++ b/locales/hexagon.pot
@@ -1,0 +1,233 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR ORGANIZATION
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2022-01-16 12:05-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+
+
+#: hexagon/__main__.py:37
+msgid "msg.main.first_time_intro"
+msgstr ""
+
+#: hexagon/__main__.py:37
+msgid "msg.main.first_time_tool"
+msgstr ""
+
+#: hexagon/actions/external/docker_registry.py:30
+msgid "action.actions.external.docker_registry.prompt_docker_image"
+msgstr ""
+
+#: hexagon/actions/external/docker_registry.py:40
+msgid "action.actions.external.docker_registry.prompt_tag"
+msgstr ""
+
+#: hexagon/actions/external/docker_registry.py:53
+msgid "action.actions.external.docker_registry.confirm_see_manifest"
+msgstr ""
+
+#: hexagon/actions/external/open_link.py:10
+msgid "msg.actions.external.open_link.result"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:20
+msgid "action.actions.internal.create_new_tool.choose_action"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:29
+msgid "action.actions.internal.create_new_tool.input_action"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:34
+msgid "action.actions.internal.create_new_tool.choose_type"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:43
+msgid "action.actions.internal.create_new_tool.input_name"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:49
+msgid "action.actions.internal.create_new_tool.input_alias"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:55
+msgid "action.actions.internal.create_new_tool.input_long_name"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:60
+msgid "action.actions.internal.create_new_tool.input_description"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:73
+msgid "action.actions.internal.create_new_tool.input_custom_tools_path"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:79
+msgid "error.actions.internal.create_new_tool.insert_valid_directory"
+msgstr ""
+
+#: hexagon/actions/internal/create_new_tool.py:84
+msgid "msg.actions.internal.create_new_tool.input_custom_tools_path_comment"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:27
+msgid "action.actions.internal.install_cli.config_file_location"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:31
+msgid "error.actions.internal.install_cli.select_valid_file"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:40
+msgid "action.actions.internal.install_cli.commands_path"
+msgstr ""
+
+#: hexagon/actions/internal/install_cli.py:44
+msgid "error.actions.internal.install_cli.select_valid_directory"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:20
+msgid "msg.actions.internal.save_new_alias.last_command"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:26
+msgid "action.actions.internal.save_new_alias.prompt_alias_name"
+msgstr ""
+
+#: hexagon/actions/internal/save_new_alias.py:28
+msgid "error.actions.internal.save_new_alias.insert_valid_alias"
+msgstr ""
+
+#: hexagon/domain/configuration.py:27
+msgid "msg.domain.configuration.save_alias_long_name"
+msgstr ""
+
+#: hexagon/domain/configuration.py:33
+msgid "msg.domain.configuration.create_tool_long_name"
+msgstr ""
+
+#: hexagon/domain/configuration.py:105
+msgid "msg.domain.configuration.install_cli_long_name"
+msgstr ""
+
+#: hexagon/domain/configuration.py:106
+msgid "msg.domain.configuration.save_alias_description"
+msgstr ""
+
+#: hexagon/support/analytics/__init__.py:78
+msgid "msg.support.analytics.telemetry_notice"
+msgstr ""
+
+#: hexagon/support/analytics/__init__.py:80
+msgid "msg.support.analytics.telemetry_directory"
+msgstr ""
+
+#: hexagon/support/analytics/__init__.py:86
+msgid "action.support.analytics.confirm_telemetry"
+msgstr ""
+
+#: hexagon/support/cli/git.py:33
+msgid "error.support.cli.git.failed_to_get_remote"
+msgstr ""
+
+#: hexagon/support/execute/action.py:59
+msgid "error.support.execute.action.command_result_code"
+msgstr ""
+
+#: hexagon/support/execute/action.py:68
+msgid "error.support.execute.action.we_tried"
+msgstr ""
+
+#: hexagon/support/execute/action.py:150
+msgid "error.support.execute.action.python_dependency_error"
+msgstr ""
+
+#: hexagon/support/execute/tool.py:79
+msgid "msg.support.execute.tool.go_back_long_name"
+msgstr ""
+
+#: hexagon/support/execute/tool.py:81
+msgid "msg.support.execute.tool.go_back_description"
+msgstr ""
+
+#: hexagon/support/execute/tool.py:82
+msgid "icon.global.go_back"
+msgstr ""
+
+#: hexagon/support/execute/tool.py:101
+msgid "error.support.execute.tool.group_tool_file_not_found"
+msgstr ""
+
+#: hexagon/support/help.py:23
+msgid "msg.support.help.no_install"
+msgstr ""
+
+#: hexagon/support/help.py:24
+msgid "msg.support.help.get_started"
+msgstr ""
+
+#: hexagon/support/hooks/hook.py:56
+msgid "error.support.hooks.hook.unknown_type"
+msgstr ""
+
+#: hexagon/support/storage.py:86
+msgid "error.support.storage.unsupported_type"
+msgstr ""
+
+#: hexagon/support/update/cli.py:49
+msgid "msg.support.update.cli.new_version_available"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:135
+msgid "msg.support.update.hexagon.fetching_changelog"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:151
+msgid "msg.support.update.hexagon.and_much_more"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:172
+msgid "msg.support.update.hexagon.new_version_available"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:186
+msgid "action.support.update.hexagon.confirm_update"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:190
+msgid "msg.support.update.hexagon.updating"
+msgstr ""
+
+#: hexagon/support/update/hexagon.py:205
+msgid "msg.support.update.hexagon.checking_new_versions"
+msgstr ""
+
+#: hexagon/support/wax.py:61
+msgid "action.support.wax.select_environment"
+msgstr ""
+
+#: hexagon/support/wax.py:66
+msgid "error.support.wax.invalid_environment"
+msgstr ""
+
+#: hexagon/support/wax.py:83
+msgid "action.support.wax.select_tool"
+msgstr ""
+
+#: hexagon/support/wax.py:86
+msgid "error.support.wax.invalid_tool"
+msgstr ""
+
+#: hexagon/support/yaml/__init__.py:15
+msgid "error.support.yaml.invalid_yaml"
+msgstr ""
+

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import setuptools
 import json
+import glob
 
 # esto se actualiza solo con https://python-semantic-release.readthedocs.io/en/latest/index.html
 __version__ = "0.22.1"
@@ -19,6 +20,8 @@ with open("Pipfile.lock", "r", encoding="utf-8") as lock:
         for name, config in json_lock["default"].items()
         if "version" in config
     ]
+
+translations = glob.glob("./locales/*/LC_MESSAGES/*.mo")
 
 setuptools.setup(
     name="hexagon",
@@ -44,5 +47,5 @@ setuptools.setup(
         hexagon=hexagon.__main__:main
     """,
     platform="debian",
-    data_files=[("*", ["Pipfile.lock"])],
+    data_files=[("*", ["Pipfile.lock"]), ("locales", translations)],
 )

--- a/tests/cli/test_wax.py
+++ b/tests/cli/test_wax.py
@@ -82,13 +82,13 @@ def test_tool_is_selected_by_prompt(monkeypatch, tool_mock, analytics_mock):
     monkeypatch.setattr(analytics, "user_event", analytics_mock)
 
     assert select_tool(tools) == Tool(name="docker", alias="d", action="docker_run")
-    assert tool_mock.args[0] == "Hi, which tool would you like to use today?"
+    assert tool_mock.args[0] == "action.support.wax.select_tool"
     assert tool_mock.args[1] == [
         {"value": "docker", "name": "  docker"},
         {"value": "bastion", "name": "  bastion"},
         {"value": "no_alias", "name": "  no_alias"},
     ]
-    assert tool_mock.args[3] == "Please select a valid tool"
+    assert tool_mock.args[3] == "error.support.wax.invalid_tool"
 
 
 def test_tool_has_no_env_property():
@@ -112,9 +112,9 @@ def test_env_is_selected_by_prompt(monkeypatch, env_mock, analytics_mock):
     monkeypatch.setattr(analytics, "user_event", analytics_mock)
 
     assert select_env(envs, tool_envs) == (envs[0], "env_1")
-    assert env_mock.args[0] == "On which environment?"
+    assert env_mock.args[0] == "action.support.wax.select_environment"
     assert env_mock.args[1] == [
         {"value": "dev", "name": "dev"},
         {"value": "qa", "name": "qa"},
     ]
-    assert env_mock.args[3] == "Please select a valid environment"
+    assert env_mock.args[3] == "error.support.wax.invalid_environment"

--- a/tests/cli/test_wax.py
+++ b/tests/cli/test_wax.py
@@ -82,13 +82,13 @@ def test_tool_is_selected_by_prompt(monkeypatch, tool_mock, analytics_mock):
     monkeypatch.setattr(analytics, "user_event", analytics_mock)
 
     assert select_tool(tools) == Tool(name="docker", alias="d", action="docker_run")
-    assert tool_mock.args[0] == "action.support.wax.select_tool"
+    assert tool_mock.args[0] == "Hi, which tool would you like to use today?"
     assert tool_mock.args[1] == [
         {"value": "docker", "name": "  docker"},
         {"value": "bastion", "name": "  bastion"},
         {"value": "no_alias", "name": "  no_alias"},
     ]
-    assert tool_mock.args[3] == "error.support.wax.invalid_tool"
+    assert tool_mock.args[3] == "Please select a valid tool"
 
 
 def test_tool_has_no_env_property():
@@ -112,9 +112,9 @@ def test_env_is_selected_by_prompt(monkeypatch, env_mock, analytics_mock):
     monkeypatch.setattr(analytics, "user_event", analytics_mock)
 
     assert select_env(envs, tool_envs) == (envs[0], "env_1")
-    assert env_mock.args[0] == "action.support.wax.select_environment"
+    assert env_mock.args[0] == "On which environment?"
     assert env_mock.args[1] == [
         {"value": "dev", "name": "dev"},
         {"value": "qa", "name": "qa"},
     ]
-    assert env_mock.args[3] == "error.support.wax.invalid_environment"
+    assert env_mock.args[3] == "Please select a valid environment"


### PR DESCRIPTION
# soporte de i18n con gettext

se expone en el modulo `printer` un `translator` para soportar la internacionalización de mensajes. Uso:
```python
from hexagon.support.printer import translator
_ = translator
_("message.id")
``` 

## Comportamiento

Va a buscar los archivos con tranducciones en el directorio `locales` y en el caso de que no exista para el lenguaje se usa `en` por defecto.

disclaimer: para el soporte de colores tuve que hacer cosas como estas: https://github.com/redbeestudios/hexagon/pull/73/files#diff-362bb29c5d12f345a46e35b8d80362afe598fad8ee14a43813a32c6c4096c144R283