### PR TITLE
fix(i18n): search local and system dirs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,4 @@ max-line-length = 88
 # see https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
 select = C, E, F, W, B, B950
 extend-ignore = E203, E501
+builtins = _

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include Pipfile.lock

--- a/e2e/i18n/app.yml
+++ b/e2e/i18n/app.yml
@@ -1,0 +1,26 @@
+cli:
+  name: Test
+  command: hexagon-test
+  custom_tools_dir: .
+
+envs:
+  - name: dev
+    alias: d
+    long_name: dev
+  - name: qa
+    alias: q
+    long_name: qa
+
+tools:
+  - name: google
+    long_name: Google
+    type: web
+    action: open_link
+    envs:
+      "*": https://www.google.com/
+
+  - name: python-i18n
+    action: echo "stub"
+    type: shell
+    alias: pm
+    long_name: Python i18n Test

--- a/e2e/tests/i18n.py
+++ b/e2e/tests/i18n.py
@@ -1,0 +1,141 @@
+from e2e.tests.utils.hexagon_spec import as_a_user
+
+
+def test_default_locale_is_english():
+    (
+        as_a_user(__file__)
+        .run_hexagon()
+        .then_output_should_be(
+            [
+                "Hi, which tool would you like to use today?",
+                "┌──────────────────────────────────────────────────────────────────────────────",
+                "",
+                "",
+                "",
+                "⦾ Google",
+                "",
+                "ƒ Python i18n Test",
+            ]
+        )
+        .then_output_should_be(
+            [
+                "└──────────────────────────────────────────────────────────────────────────────",
+                "",
+            ],
+            True,
+        )
+        .arrow_down()
+        .enter()
+        .then_output_should_be(
+            [
+                ["Hi, which tool would you like to use today?", "ƒ Python i18n Test"],
+                "stub",
+            ]
+        )
+        .exit()
+    )
+
+
+def test_fallback_locale_is_english():
+    (
+        as_a_user(__file__)
+        .run_hexagon(os_env_vars={"LANGUAGE": "fr"})
+        .then_output_should_be(
+            [
+                "Hi, which tool would you like to use today?",
+                "┌──────────────────────────────────────────────────────────────────────────────",
+                "",
+                "",
+                "",
+                "⦾ Google",
+                "",
+                "ƒ Python i18n Test",
+            ]
+        )
+        .then_output_should_be(
+            [
+                "└──────────────────────────────────────────────────────────────────────────────",
+                "",
+            ],
+            True,
+        )
+        .arrow_down()
+        .enter()
+        .then_output_should_be(
+            [
+                ["Hi, which tool would you like to use today?", "ƒ Python i18n Test"],
+                "stub",
+            ]
+        )
+        .exit()
+    )
+
+
+def test_locale_is_set_to_english():
+    (
+        as_a_user(__file__)
+        .run_hexagon(os_env_vars={"LANGUAGE": "en"})
+        .then_output_should_be(
+            [
+                "Hi, which tool would you like to use today?",
+                "┌──────────────────────────────────────────────────────────────────────────────",
+                "",
+                "",
+                "",
+                "⦾ Google",
+                "",
+                "ƒ Python i18n Test",
+            ]
+        )
+        .then_output_should_be(
+            [
+                "└──────────────────────────────────────────────────────────────────────────────",
+                "",
+            ],
+            True,
+        )
+        .arrow_down()
+        .enter()
+        .then_output_should_be(
+            [
+                ["Hi, which tool would you like to use today?", "ƒ Python i18n Test"],
+                "stub",
+            ]
+        )
+        .exit()
+    )
+
+
+def test_locale_is_set_to_spanish():
+    (
+        as_a_user(__file__)
+        .run_hexagon(os_env_vars={"LANGUAGE": "es"})
+        .then_output_should_be(
+            [
+                "Hola ¿qué herramienta te gustaría usar hoy?",
+                "┌──────────────────────────────────────────────────────────────────────────────",
+                "",
+                "",
+                "",
+                "⦾ Google",
+                "",
+                "ƒ Python i18n Test",
+            ]
+        )
+        .then_output_should_be(
+            [
+                "└──────────────────────────────────────────────────────────────────────────────",
+                "",
+            ],
+            True,
+        )
+        .arrow_down()
+        .enter()
+        .then_output_should_be(
+            [
+                ["Hola ¿qué herramienta te gustaría usar hoy?", "ƒ Python i18n Test"],
+                "stub",
+            ]
+        )
+        .exit()
+    )

--- a/hexagon/__main__.py
+++ b/hexagon/__main__.py
@@ -1,21 +1,19 @@
-from hexagon.support.hooks import HexagonHooks
-from hexagon.support.execute.tool import select_and_execute_tool
-from hexagon.support.update.cli import check_for_cli_updates
 import sys
 
-from hexagon.support.args import fill_args
 from hexagon.domain import cli, tools, envs
+from hexagon.plugins import collect_plugins
+from hexagon.support.args import fill_args
+from hexagon.support.execute.tool import select_and_execute_tool
 from hexagon.support.help import print_help
-from hexagon.support.tracer import tracer
-from hexagon.support.printer import log, translator
-from hexagon.support.update.hexagon import check_for_hexagon_updates
+from hexagon.support.hooks import HexagonHooks
+from hexagon.support.printer import log
 from hexagon.support.storage import (
     HexagonStorageKeys,
     store_user_data,
 )
-from hexagon.plugins import collect_plugins
-
-_ = translator
+from hexagon.support.tracer import tracer
+from hexagon.support.update.cli import check_for_cli_updates
+from hexagon.support.update.hexagon import check_for_hexagon_updates
 
 
 def main():

--- a/hexagon/actions/external/docker_registry.py
+++ b/hexagon/actions/external/docker_registry.py
@@ -6,10 +6,8 @@ import requests
 from InquirerPy import inquirer
 
 from hexagon.support.args import cli_arg
+from hexagon.support.printer import log
 from hexagon.support.tracer import tracer
-from hexagon.support.printer import log, translator
-
-_ = translator
 
 
 def main(tool, env, env_args, cli_args):

--- a/hexagon/actions/external/open_link.py
+++ b/hexagon/actions/external/open_link.py
@@ -1,8 +1,6 @@
 import webbrowser
 
-from hexagon.support.printer import log, translator
-
-_ = translator
+from hexagon.support.printer import log
 
 
 def main(tool, env, env_args, cli_args):

--- a/hexagon/actions/internal/create_new_tool.py
+++ b/hexagon/actions/internal/create_new_tool.py
@@ -4,12 +4,10 @@ from shutil import copytree
 from InquirerPy import inquirer
 from InquirerPy.validator import PathValidator
 
-from hexagon.domain.tool import ActionTool, ToolType
-from hexagon.domain import configuration
 from hexagon.actions import external
-from hexagon.support.printer import log, translator
-
-_ = translator
+from hexagon.domain import configuration
+from hexagon.domain.tool import ActionTool, ToolType
+from hexagon.support.printer import log
 
 
 def main(*__):

--- a/hexagon/actions/internal/install_cli.py
+++ b/hexagon/actions/internal/install_cli.py
@@ -6,10 +6,8 @@ from InquirerPy.validator import PathValidator
 from prompt_toolkit.validation import ValidationError
 
 from hexagon.domain import configuration
-from hexagon.support.printer import log, translator
+from hexagon.support.printer import log
 from hexagon.support.storage import load_user_data, HexagonStorageKeys, store_user_data
-
-_ = translator
 
 
 class YamlFileValidator(PathValidator):

--- a/hexagon/actions/internal/save_new_alias.py
+++ b/hexagon/actions/internal/save_new_alias.py
@@ -3,13 +3,11 @@ import os
 from InquirerPy import inquirer
 from InquirerPy.validator import EmptyInputValidator
 
-from hexagon.support.printer import log, translator
+from hexagon.support.printer import log
 from hexagon.support.storage import (
     HexagonStorageKeys,
     load_user_data,
 )
-
-_ = translator
 
 
 def main(*__):

--- a/hexagon/domain/configuration.py
+++ b/hexagon/domain/configuration.py
@@ -8,10 +8,7 @@ from ruamel.yaml import YAML
 from hexagon.domain.cli import Cli
 from hexagon.domain.env import Env
 from hexagon.domain.tool import ActionTool, GroupTool, Tool, ToolType
-from hexagon.support.printer import translator
 from hexagon.support.yaml import display_yaml_errors
-
-_ = translator
 
 
 class ConfigFile(BaseModel):

--- a/hexagon/support/analytics/__init__.py
+++ b/hexagon/support/analytics/__init__.py
@@ -1,15 +1,14 @@
-from enum import Enum
 import datetime
+from enum import Enum
 
 from InquirerPy import inquirer
 
 from hexagon.domain import get_options
 from hexagon.domain.options import update_options
-from hexagon.support.printer import log, translator
-from hexagon.support.storage import store_local_data, get_local_data_dir
 from hexagon.support.analytics import google_analytics
+from hexagon.support.printer import log
+from hexagon.support.storage import store_local_data, get_local_data_dir
 
-_ = translator
 _data_file_name = "events_" + datetime.date.today().isoformat()
 
 

--- a/hexagon/support/cli/git.py
+++ b/hexagon/support/cli/git.py
@@ -1,11 +1,8 @@
+import re
 from typing import Optional
 
 from hexagon.support.cli.command import output_from_command_in_cli_project_path
-from hexagon.support.printer import translator
 from hexagon.support.storage import load_user_data, store_user_data
-import re
-
-_ = translator
 
 
 class CliGitConfig:

--- a/hexagon/support/execute/action.py
+++ b/hexagon/support/execute/action.py
@@ -1,7 +1,7 @@
 import importlib
+import os
 import subprocess
 import sys
-import os
 import time
 import traceback
 from pathlib import Path
@@ -9,14 +9,13 @@ from typing import List, Union, Dict
 
 from rich import traceback as rich_traceback
 
+from hexagon.domain import configuration
+from hexagon.domain.env import Env
 from hexagon.domain.tool import ActionTool
 from hexagon.domain.tool.execution import ToolExecutionData
-from hexagon.domain.env import Env
-from hexagon.domain import configuration
-from hexagon.support.printer import log, translator
 from hexagon.support.hooks import HexagonHooks
+from hexagon.support.printer import log
 
-_ = translator
 _command_by_file_extension = {"js": "node", "sh": "sh"}
 
 

--- a/hexagon/support/execute/tool.py
+++ b/hexagon/support/execute/tool.py
@@ -1,8 +1,14 @@
-from hexagon.support.hooks import HexagonHooks
-from hexagon.support.yaml import display_yaml_errors
+import os
+import sys
+from typing import List, Tuple
+
 from prompt_toolkit.validation import ValidationError
-from hexagon.support.execute.action import execute_action
-from hexagon.support.wax import search_by_name_or_alias, select_env, select_tool
+
+from hexagon.domain import envs, configuration
+from hexagon.domain.configuration import (
+    read_configuration_file,
+    register_custom_tools_path,
+)
 from hexagon.domain.tool import (
     FunctionTool,
     GroupTool,
@@ -11,18 +17,12 @@ from hexagon.domain.tool import (
     ToolType,
 )
 from hexagon.domain.tool.execution import ToolExecutionParamters
-from typing import List, Tuple
-from hexagon.domain import envs, configuration
+from hexagon.support.execute.action import execute_action
+from hexagon.support.hooks import HexagonHooks
+from hexagon.support.printer import log
 from hexagon.support.tracer import tracer
-from hexagon.domain.configuration import (
-    read_configuration_file,
-    register_custom_tools_path,
-)
-from hexagon.support.printer import log, translator
-import sys
-import os
-
-_ = translator
+from hexagon.support.wax import search_by_name_or_alias, select_env, select_tool
+from hexagon.support.yaml import display_yaml_errors
 
 
 def select_and_execute_tool(

--- a/hexagon/support/help.py
+++ b/hexagon/support/help.py
@@ -1,12 +1,10 @@
 from itertools import groupby
 from typing import List
 
+from hexagon.domain.cli import Cli
 from hexagon.domain.env import Env
 from hexagon.domain.tool import Tool
-from hexagon.domain.cli import Cli
-from hexagon.support.printer import log, translator
-
-_ = translator
+from hexagon.support.printer import log
 
 
 def print_help(cli_config: Cli, tools: List[Tool], envs: List[Env]):

--- a/hexagon/support/hooks/hook.py
+++ b/hexagon/support/hooks/hook.py
@@ -1,10 +1,6 @@
+import threading
 from enum import Enum
 from typing import Callable, Generic, List, TypeVar
-import threading
-
-from hexagon.support.printer import translator
-
-_ = translator
 
 
 class HookSubscrptionType(Enum):

--- a/hexagon/support/printer/__init__.py
+++ b/hexagon/support/printer/__init__.py
@@ -1,25 +1,13 @@
-import os
 from typing import Callable
 
 from rich.console import Console
 
 from hexagon.support.printer.logger import Logger
 from hexagon.support.printer.themes import load_theme
-
-import gettext
-
-LOCALEDIR = os.environ.get("HEXAGON_LOCALES_DIR", "locales")
+from hexagon.support.printer.i18n import install
 
 theme = load_theme()
 
 log = Logger(Console(color_system="auto" if theme.show_colors else None), theme)
 
-try:
-    el = gettext.translation("hexagon", localedir=LOCALEDIR)
-except FileNotFoundError:
-    el = gettext.translation(
-        "hexagon", localedir=LOCALEDIR, languages=["en"], fallback=True
-    )
-el.install()
-
-translator: Callable[[str], str] = el.gettext
+translator: Callable[[str], str] = install()

--- a/hexagon/support/printer/__init__.py
+++ b/hexagon/support/printer/__init__.py
@@ -1,13 +1,11 @@
-from typing import Callable
-
 from rich.console import Console
 
+from hexagon.support.printer.i18n import install
 from hexagon.support.printer.logger import Logger
 from hexagon.support.printer.themes import load_theme
-from hexagon.support.printer.i18n import install
 
 theme = load_theme()
 
 log = Logger(Console(color_system="auto" if theme.show_colors else None), theme)
 
-translator: Callable[[str], str] = install()
+install()

--- a/hexagon/support/printer/i18n.py
+++ b/hexagon/support/printer/i18n.py
@@ -1,0 +1,46 @@
+import os
+import site
+import sys
+
+import gettext
+
+LOCALEDIR = os.environ.get("HEXAGON_LOCALES_DIR", None)
+
+# site.USER_BASE is usually ~/.local (this is used when pip WAS NOT installed globally)
+LOCAL_LOCALEDIR = os.path.join(site.USER_BASE, "locales")
+
+# sys.prefix is usually /usr/local (this is used when pip WAS installed globally)
+SYSTEM_LOCALEDIR = os.path.join(sys.prefix, "locales")
+
+DEFAULT_LANGUAGE = "en"
+
+
+def install():
+    el = lookup_localedir() if LOCALEDIR else lookup_install_localedirs()
+
+    el.install()
+
+    return el.gettext
+
+
+def lookup_install_localedirs():
+    return (
+        __try_translation(localedir=LOCAL_LOCALEDIR)
+        or __try_translation(localedir=LOCAL_LOCALEDIR, languages=[DEFAULT_LANGUAGE])
+        or __try_translation(localedir=SYSTEM_LOCALEDIR)
+        or __try_translation(localedir=SYSTEM_LOCALEDIR, languages=[DEFAULT_LANGUAGE])
+        or __try_translation(fallback=True)
+    )
+
+
+def lookup_localedir():
+    return __try_translation(localedir=LOCALEDIR) or __try_translation(
+        localedir=LOCALEDIR, languages=[DEFAULT_LANGUAGE]
+    )
+
+
+def __try_translation(**kwargs):
+    try:
+        return gettext.translation("hexagon", **kwargs)
+    except FileNotFoundError:
+        return None

--- a/hexagon/support/update/cli.py
+++ b/hexagon/support/update/cli.py
@@ -1,17 +1,17 @@
-from hexagon.support.cli.git import load_cli_git_config
+import os
+import re
+import sys
+
+from InquirerPy import inquirer
+
+from hexagon.domain import cli
 from hexagon.support.cli.command import (
     execute_command_in_cli_project_path,
     output_from_command_in_cli_project_path,
 )
-from hexagon.support.printer import log, translator
+from hexagon.support.cli.git import load_cli_git_config
+from hexagon.support.printer import log
 from hexagon.support.update.shared import already_checked_for_updates
-import os
-import re
-from hexagon.domain import cli
-from InquirerPy import inquirer
-import sys
-
-_ = translator
 
 
 def check_for_cli_updates():

--- a/hexagon/support/update/hexagon.py
+++ b/hexagon/support/update/hexagon.py
@@ -1,22 +1,22 @@
-from hexagon.support.storage import HEXAGON_STORAGE_APP
-from hexagon.support.update.shared import already_checked_for_updates
-from hexagon.support.github import add_github_access_token
-import re
-from typing import List, Optional
-import pkg_resources
 import json
 import os
+import re
 import subprocess
 import sys
-from urllib.request import Request, urlopen
-from packaging.version import parse as parse_version, Version
-from markdown import Markdown
-from io import StringIO
-from hexagon.support.printer import log, translator
-from InquirerPy import inquirer
 from functools import reduce
+from io import StringIO
+from typing import List, Optional
+from urllib.request import Request, urlopen
 
-_ = translator
+import pkg_resources
+from InquirerPy import inquirer
+from markdown import Markdown
+from packaging.version import parse as parse_version, Version
+
+from hexagon.support.github import add_github_access_token
+from hexagon.support.printer import log
+from hexagon.support.storage import HEXAGON_STORAGE_APP
+from hexagon.support.update.shared import already_checked_for_updates
 
 LAST_UPDATE_DATE_FORMAT = "%Y%m%d"
 REPO_ORG = "redbeestudios"

--- a/hexagon/support/wax.py
+++ b/hexagon/support/wax.py
@@ -6,9 +6,6 @@ from hexagon.domain.env import Env
 from hexagon.domain.tool import Tool
 from hexagon.domain.wax import Selection, SelectionType
 from hexagon.support.hooks import HexagonHooks
-from hexagon.support.printer import translator
-
-_ = translator
 
 
 def __classifier(value: Union[Tool, Env]):

--- a/hexagon/support/yaml/__init__.py
+++ b/hexagon/support/yaml/__init__.py
@@ -2,9 +2,7 @@ from pydantic import ValidationError
 from rich.syntax import Syntax
 from ruamel import yaml
 
-from hexagon.support.printer import log, translator
-
-_ = translator
+from hexagon.support.printer import log
 
 
 def display_yaml_errors(errors: ValidationError, ruamel_yaml=None, yaml_path=None):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
+from os.path import dirname
+
 import setuptools
 import json
+
 import glob
 
 # esto se actualiza solo con https://python-semantic-release.readthedocs.io/en/latest/index.html
@@ -21,7 +24,7 @@ with open("Pipfile.lock", "r", encoding="utf-8") as lock:
         if "version" in config
     ]
 
-translations = glob.glob("./locales/*/LC_MESSAGES/*.mo")
+translations = [(dirname(x), [x]) for x in glob.glob("locales/*/LC_MESSAGES/*.mo")]
 
 setuptools.setup(
     name="hexagon",
@@ -39,13 +42,12 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=setuptools.find_packages(exclude=["tests", "tests.*", "e2e", "e2e.*"]),
-    package_data={"": ["*.md"]},
+    package_data={"": ["*.md", "Pipfile.lock"]},
     install_requires=requires,
     python_requires=">=3.7",
     entry_points="""
         [console_scripts]
         hexagon=hexagon.__main__:main
     """,
-    platform="debian",
-    data_files=[("*", ["Pipfile.lock"]), ("locales", translations)],
+    data_files=translations,
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=setuptools.find_packages(exclude=["tests", "tests.*", "e2e", "e2e.*"]),
-    package_data={"": ["*.md", "Pipfile.lock"]},
+    include_package_data=True,
     install_requires=requires,
     python_requires=">=3.7",
     entry_points="""


### PR DESCRIPTION
lookup is done:
 1. HEXAGON_LOCALES_DIR if present
 2. local install dir (~/.local)
 4. system install dir (/usr/local)
 6. default gettext lookup dir or fallback

el cambio de comportamiento es hasta acá https://github.com/redbeestudios/hexagon/compare/main...e3fa865b53bab44a054791edfacc31dd60bf410f. El siguiente commit es un refactor general para dejar de usar `_ = translator` ya que el `el.install()` que se hace en i18n.py es basicamente para instalar `_` como un builtin